### PR TITLE
Create Intermediate Data Representation Format structures for DDL

### DIFF
--- a/idrf/idrf.go
+++ b/idrf/idrf.go
@@ -103,18 +103,18 @@ func (d DataType) String() string {
 	case IDRFString:
 		return "IDRFString"
 	default:
-		return fmt.Sprintf("%d", int(d))
+		panic("Unexpected value")
 	}
 }
 
 // ForeignKeyDescription describes a foreign key relationship to a IDRF data set's column
 type ForeignKeyDescription struct {
-	dataSet    DataSetInfo
+	dataSet    *DataSetInfo
 	columnName string
 }
 
 // NewForeignKey creates a new instance of ForeignKeyDescription with checked arguments
-func NewForeignKey(dataSet DataSetInfo, columnName string) (*ForeignKeyDescription, error) {
+func NewForeignKey(dataSet *DataSetInfo, columnName string) (*ForeignKeyDescription, error) {
 	columnExistsInDataSet := dataSet.ColumnNamed(columnName) != nil
 	if !columnExistsInDataSet {
 		return nil, fmt.Errorf("Column %s not part of data set %s", columnName, dataSet.dataSetName)

--- a/idrf/idrf_test.go
+++ b/idrf/idrf_test.go
@@ -11,7 +11,7 @@ func TestNewForeignKey(t *testing.T) {
 	wrongColumnName := "Wrong Column"
 	goodColumnName := "Column 1"
 
-	foreignKey, error := NewForeignKey(dataSetNoColumns, wrongColumnName)
+	foreignKey, error := NewForeignKey(&dataSetNoColumns, wrongColumnName)
 	if error == nil || foreignKey != nil {
 		t.Error("Error should have been returned because column is not in data set")
 	}
@@ -20,12 +20,12 @@ func TestNewForeignKey(t *testing.T) {
 		ColumnInfo{name: goodColumnName, dataType: IDRFInteger},
 	}}
 
-	foreignKey, error = NewForeignKey(dataSetWithColumns, wrongColumnName)
+	foreignKey, error = NewForeignKey(&dataSetWithColumns, wrongColumnName)
 	if error == nil || foreignKey != nil {
 		t.Error("Error should have been returned because column is not in data set")
 	}
 
-	foreignKey, error = NewForeignKey(dataSetWithColumns, goodColumnName)
+	foreignKey, error = NewForeignKey(&dataSetWithColumns, goodColumnName)
 	if error != nil || foreignKey == nil {
 		t.Error("Error should not have been returned, column is in the data set")
 	}
@@ -47,7 +47,7 @@ func TestNewColumnWithFK(t *testing.T) {
 		dataSetName: "DSName",
 		columns:     []ColumnInfo{ColumnInfo{name: foreignColumn, dataType: IDRFFloating}},
 	}
-	goodForeignKey, err := NewForeignKey(goodDataSet, foreignColumn)
+	goodForeignKey, err := NewForeignKey(&goodDataSet, foreignColumn)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}


### PR DESCRIPTION
Structures for Data set description, column descriptions along with foreign key
relationships.
Unit tests writen for the functions that create the structures and also validate the
arguments.