### PR TITLE
Influx extractor converts to IDRF instead of Ingestor

### DIFF
--- a/internal/extraction/idrfconversion/idrf_converter.go
+++ b/internal/extraction/idrfconversion/idrf_converter.go
@@ -1,4 +1,4 @@
-package ingestion
+package idrfconversion
 
 import (
 	"encoding/json"
@@ -8,11 +8,14 @@ import (
 	"github.com/timescale/outflux/internal/idrf"
 )
 
+// IdrfConverter defines methods to convert the results of an InfluxDB Query result row to IDRF
 type IdrfConverter interface {
-	ConvertValues(row idrf.Row) ([]interface{}, error)
+	Convert(row []interface{}) (idrf.Row, error)
 }
 
-func newIdrfConverter(dataSet *idrf.DataSetInfo) IdrfConverter {
+// NewIdrfConverter creates an instance of the IdrfConverter that converts the results
+// of an InfluxDB Query result row to IDRF
+func NewIdrfConverter(dataSet *idrf.DataSetInfo) IdrfConverter {
 	return &defaultIdrfConverter{dataSet}
 }
 
@@ -20,7 +23,7 @@ type defaultIdrfConverter struct {
 	dataSet *idrf.DataSetInfo
 }
 
-func (conv *defaultIdrfConverter) ConvertValues(row idrf.Row) ([]interface{}, error) {
+func (conv *defaultIdrfConverter) Convert(row []interface{}) (idrf.Row, error) {
 	if len(row) != len(conv.dataSet.Columns) {
 		return nil, fmt.Errorf(
 			"could not convert extracted row, number of extracted values is %d, expected %d values",

--- a/internal/extraction/idrfconversion/idrf_converter_test.go
+++ b/internal/extraction/idrfconversion/idrf_converter_test.go
@@ -1,4 +1,4 @@
-package ingestion
+package idrfconversion
 
 import (
 	"encoding/json"
@@ -57,7 +57,7 @@ func TestConvertValues(t *testing.T) {
 
 	for _, tc := range tcs {
 		conv := &defaultIdrfConverter{dataSet: tc.ds}
-		res, err := conv.ConvertValues(tc.in)
+		res, err := conv.Convert(tc.in)
 		if tc.expectErr && err == nil {
 			t.Error("expected an error, none received")
 		}

--- a/internal/extraction/influx_data_producer_test.go
+++ b/internal/extraction/influx_data_producer_test.go
@@ -64,7 +64,7 @@ func TestBuildSelectCommand(t *testing.T) {
 }
 
 func TestFetchWhenErrorsHappenOnErrSub(t *testing.T) {
-	producer := defaultDataProducer{"id", &mockConnService{}}
+	producer := defaultDataProducer{"id", &mockConnService{}, nil}
 	query := influx.Query{}
 	dataChannel := make(chan idrf.Row)
 	errorChannel := make(chan error, 1)
@@ -82,7 +82,7 @@ func TestFetchWhenErrorsHappenOnErrSub(t *testing.T) {
 	}
 }
 func TestFetchWhenErrorsHappenOnClientCreate(t *testing.T) {
-	producer := defaultDataProducer{"id", errorReturningConnService()}
+	producer := defaultDataProducer{"id", errorReturningConnService(), nil}
 	query := influx.Query{}
 	dataChannel := make(chan idrf.Row)
 	errorChannel := make(chan error, 1)
@@ -104,7 +104,7 @@ func TestFetchWhenErrorsHappenOnClientCreate(t *testing.T) {
 
 func TestFetchWhenErrorsHappenOnQueryAsChunk(t *testing.T) {
 	mockedClient := errorReturningMockClient()
-	producer := defaultDataProducer{"id", mockedConnService(mockedClient)}
+	producer := defaultDataProducer{"id", mockedConnService(mockedClient), nil}
 
 	query := influx.Query{}
 	dataChannel := make(chan idrf.Row)

--- a/internal/extraction/influx_extractor.go
+++ b/internal/extraction/influx_extractor.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/timescale/outflux/internal/extraction/idrfconversion"
+
 	influx "github.com/influxdata/influxdb/client/v2"
 	"github.com/timescale/outflux/internal/connections"
 	"github.com/timescale/outflux/internal/extraction/config"
@@ -37,9 +39,10 @@ func NewExtractor(extractionConfig *config.Config, connectionService connections
 		return nil, fmt.Errorf("DataSet info can not be nil")
 	}
 
+	converter := idrfconversion.NewIdrfConverter(extractionConfig.DataSet)
 	return &defaultInfluxExtractor{
 		config:   extractionConfig,
-		producer: NewDataProducer(extractionConfig.ExtractorID, connectionService),
+		producer: NewDataProducer(extractionConfig.ExtractorID, connectionService, converter),
 	}, nil
 }
 

--- a/internal/extraction/query_building.go
+++ b/internal/extraction/query_building.go
@@ -1,0 +1,48 @@
+package extraction
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/timescale/outflux/internal/extraction/config"
+	"github.com/timescale/outflux/internal/idrf"
+)
+
+func buildSelectCommand(config *config.MeasureExtraction, columns []*idrf.ColumnInfo) string {
+	projection := buildProjection(columns)
+	var command string
+	if config.From != "" && config.To != "" {
+		command = fmt.Sprintf(selectQueryDoubleBoundTemplate, projection, config.Measure, config.From, config.To)
+	} else if config.From != "" {
+		command = fmt.Sprintf(selectQueryLowerBoundTemplate, projection, config.Measure, config.From)
+	} else if config.To != "" {
+		command = fmt.Sprintf(selectQueryUpperBoundTemplate, projection, config.Measure, config.To)
+	} else {
+		command = fmt.Sprintf(selectQueryNoBoundTemplate, projection, config.Measure)
+	}
+
+	if config.Limit == 0 {
+		return command
+	}
+
+	limit := fmt.Sprintf(limitSuffixTemplate, config.Limit)
+	return fmt.Sprintf("%s %s", command, limit)
+}
+
+func buildProjection(columns []*idrf.ColumnInfo) string {
+	columnNames := make([]string, len(columns))
+	for i, column := range columns {
+		columnNames[i] = fmt.Sprintf("\"%s\"", column.Name)
+	}
+
+	return strings.Join(columnNames, ", ")
+}
+
+func checkError(errorChannel chan error) error {
+	select {
+	case err := <-errorChannel:
+		return err
+	default:
+		return nil
+	}
+}

--- a/internal/ingestion/ingestor.go
+++ b/internal/ingestion/ingestor.go
@@ -27,7 +27,6 @@ func NewIngestor(
 	dataChannel chan idrf.Row) Ingestor {
 	return &defaultIngestor{
 		config:           config,
-		converter:        newIdrfConverter(dataSet),
 		dataChannel:      dataChannel,
 		ingestionRoutine: NewIngestionRoutine(),
 		dbConn:           dbConn,
@@ -38,7 +37,6 @@ func NewIngestor(
 
 type defaultIngestor struct {
 	config           *IngestorConfig
-	converter        IdrfConverter
 	ingestionRoutine Routine
 	schemaManager    schemamanagement.SchemaManager
 	dbConn           *pgx.Conn
@@ -56,7 +54,6 @@ func (ing *defaultIngestor) Start(errorBroadcaster utils.ErrorBroadcaster) chan 
 		errorBroadcaster:        errorBroadcaster,
 		ackChannel:              ackChannel,
 		dataChannel:             ing.dataChannel,
-		converter:               ing.converter,
 		rollbackOnExternalError: ing.config.RollbackOnExternalError,
 		batchSize:               ing.config.BatchSize,
 		dbConn:                  ing.dbConn,


### PR DESCRIPTION
Originally a row from the Influx query was passed to the Ingestor as-is, and converted to go types before being inserted into Timescale. The proper way to do this is to convert the Influx row to go types (as per the Intermediate Data Representation Format), and then pass it on down the pipeline.
This will allow for future expansion of Outflux to support data transformations on the way to the target db