### PR TITLE
Improve log information when doing schema-transfer

### DIFF
--- a/internal/extraction/influx/influx_extractor.go
+++ b/internal/extraction/influx/influx_extractor.go
@@ -27,11 +27,15 @@ func (e *Extractor) ID() string {
 
 // Prepare discoveres the data set schema for the measure in the config
 func (e *Extractor) Prepare() (*idrf.Bundle, error) {
-	discoveredDataSet, err := e.SM.FetchDataSet(e.Config.MeasureExtraction.Measure)
+	measureName := e.Config.MeasureExtraction.Measure
+	log.Printf("Discovering influx schema for measurement: %s", measureName)
+
+	discoveredDataSet, err := e.SM.FetchDataSet(measureName)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%s: could not fetch data set definition for measure: %s\n%v", e.ID(), measureName, err)
 	}
 
+	log.Printf("Discovered: %s", discoveredDataSet.String())
 	e.cachedElementData = &idrf.Bundle{
 		DataDef: discoveredDataSet,
 		Data:    make(chan idrf.Row, e.Config.DataBufferSize),

--- a/internal/idrf/column_info.go
+++ b/internal/idrf/column_info.go
@@ -9,7 +9,7 @@ type ColumnInfo struct {
 }
 
 func (c ColumnInfo) String() string {
-	return fmt.Sprintf("ColumnInfo { name: %s, dataType: %s}", c.Name, c.DataType.String())
+	return fmt.Sprintf("ColumnInfo{%s, %s}", c.Name, c.DataType.String())
 }
 
 // NewColumn creates a new ColumnInfo without a foreign key while checking the arguments

--- a/internal/idrf/data_set.go
+++ b/internal/idrf/data_set.go
@@ -16,7 +16,7 @@ type DataSet struct {
 }
 
 func (set *DataSet) String() string {
-	return fmt.Sprintf("DataSet { dataSetName: %s, columns: %s, time column: %s }", set.DataSetName, set.Columns, set.TimeColumn)
+	return fmt.Sprintf("DataSet { Name: %s, Columns: %s, Time Column: %s }", set.DataSetName, set.Columns, set.TimeColumn)
 }
 
 // ColumnNamed returns the ColumnInfo for a column given it's name, or nil if no column

--- a/internal/pipeline/pipe_service.go
+++ b/internal/pipeline/pipe_service.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	pipeIDTemplate = "pipe_%d"
+	pipeIDTemplate = "pipe_%s"
 )
 
 // PipeService defines methods for creating pipelines
@@ -45,7 +45,7 @@ func NewPipeService(
 func (s *pipeService) Create(connConf *ConnectionConfig, conf *MigrationConfig) []Pipe {
 	pipes := make([]Pipe, len(connConf.InputMeasures))
 	for i, measure := range connConf.InputMeasures {
-		pipeID := fmt.Sprintf(pipeIDTemplate, i)
+		pipeID := fmt.Sprintf(pipeIDTemplate, measure)
 		pipeConf := &PipeConfig{
 			extraction:  s.extractionConfCreator.create(pipeID, connConf.InputDb, measure, conf),
 			ingestion:   s.ingestionConfCreator.create(pipeID, conf),

--- a/internal/schemamanagement/influx/dataset_constructor.go
+++ b/internal/schemamanagement/influx/dataset_constructor.go
@@ -1,6 +1,8 @@
 package influx
 
 import (
+	"fmt"
+
 	influx "github.com/influxdata/influxdb/client/v2"
 	"github.com/timescale/outflux/internal/idrf"
 	"github.com/timescale/outflux/internal/schemamanagement/influx/discovery"
@@ -32,12 +34,12 @@ type defaultDSConstructor struct {
 func (d *defaultDSConstructor) construct(measure string) (*idrf.DataSet, error) {
 	idrfTags, err := d.tagExplorer.DiscoverMeasurementTags(d.influxClient, d.database, measure)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("could not discover the tags of measurement '%s'\n%v", measure, err)
 	}
 
 	idrfFields, err := d.fieldExplorer.DiscoverMeasurementFields(d.influxClient, d.database, measure)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("could not discover the fields of measure '%s'\n%v", measure, err)
 	}
 
 	idrfTimeColumn, _ := idrf.NewColumn("time", idrf.IDRFTimestamp)

--- a/internal/schemamanagement/influx/discovery/field_discovery.go
+++ b/internal/schemamanagement/influx/discovery/field_discovery.go
@@ -30,7 +30,7 @@ func NewFieldExplorer(queryService influxqueries.InfluxQueryService) FieldExplor
 func (fe *defaultFieldExplorer) DiscoverMeasurementFields(influxClient influx.Client, database, measurement string) ([]*idrf.ColumnInfo, error) {
 	fields, err := fe.fetchMeasurementFields(influxClient, database, measurement)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error fetching fields for measurement '%s'\n%v", measurement, err)
 	}
 
 	return convertFields(fields)
@@ -41,7 +41,7 @@ func (fe *defaultFieldExplorer) fetchMeasurementFields(influxClient influx.Clien
 	result, err := fe.queryService.ExecuteShowQuery(influxClient, database, showFieldsQuery)
 
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error executing query: %s\n%v", showFieldsQuery, err)
 	}
 
 	if len(result.Values) == 0 {
@@ -73,7 +73,7 @@ func convertFields(fieldsWithType [][2]string) ([]*idrf.ColumnInfo, error) {
 		idrfColumn, err := idrf.NewColumn(field[0], columnType)
 
 		if err != nil {
-			return nil, fmt.Errorf("could not convert fields to IDRF. " + err.Error())
+			return nil, fmt.Errorf("could not convert fields to IDRF. \n%v", err.Error())
 		}
 
 		columns[i] = idrfColumn

--- a/internal/schemamanagement/influx/discovery/measure_discovery.go
+++ b/internal/schemamanagement/influx/discovery/measure_discovery.go
@@ -32,9 +32,8 @@ func NewMeasureExplorer(queryService influxqueries.InfluxQueryService) MeasureEx
 // or an error if the query could not be executed, or the result was in an unexpected format
 func (me *defaultMeasureExplorer) FetchAvailableMeasurements(influxClient influx.Client, database string) ([]string, error) {
 	result, err := me.queryService.ExecuteShowQuery(influxClient, database, showMeasurementsQuery)
-
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error executing query: %s\nerror: %v", showMeasurementsQuery, err)
 	}
 
 	measureNames := make([]string, len(result.Values))

--- a/internal/schemamanagement/influx/discovery/tag_discovery.go
+++ b/internal/schemamanagement/influx/discovery/tag_discovery.go
@@ -33,7 +33,7 @@ func (te *defaultTagExplorer) DiscoverMeasurementTags(influxClient influx.Client
 	tags, err := te.fetchMeasurementTags(influxClient, database, measure)
 
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error fetching tags for measurement '%s'\n%v", measure, err)
 	}
 
 	return convertTags(tags)
@@ -44,7 +44,7 @@ func (te *defaultTagExplorer) fetchMeasurementTags(influxClient influx.Client, d
 	result, err := te.queryService.ExecuteShowQuery(influxClient, database, showTagsQuery)
 
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error executing query: %s\n%v", showTagsQuery, err)
 	}
 
 	if len(result.Values) == 0 {
@@ -71,7 +71,7 @@ func convertTags(tags []string) ([]*idrf.ColumnInfo, error) {
 		idrfColumn, err := idrf.NewColumn(tag, idrf.IDRFString)
 
 		if err != nil {
-			return nil, fmt.Errorf("Could not convert tags to IDRF. " + err.Error())
+			return nil, fmt.Errorf("Could not convert tags to IDRF. \n%v" + err.Error())
 		}
 
 		columns[i] = idrfColumn

--- a/internal/schemamanagement/influx/influx_schema_manager.go
+++ b/internal/schemamanagement/influx/influx_schema_manager.go
@@ -41,7 +41,7 @@ func (sm *SchemaManager) DiscoverDataSets() ([]string, error) {
 func (sm *SchemaManager) FetchDataSet(dataSetIdentifier string) (*idrf.DataSet, error) {
 	measurements, err := sm.measureExplorer.FetchAvailableMeasurements(sm.influxClient, sm.database)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("could not fetch available measurements from InfluxDB\n%v", err)
 	}
 
 	measureMissing := true


### PR DESCRIPTION
Some of the errors when logged did not contain context information, as reported in #23. Also more log info was added to the code doing schema discovery