### PR TITLE
Use double quotes for escaping column names when preparing output db

### DIFF
--- a/internal/schemamanagement/ts/table_creator.go
+++ b/internal/schemamanagement/ts/table_creator.go
@@ -30,8 +30,7 @@ func newTableCreator() tableCreator {
 type defaultTableCreator struct{}
 
 func (d *defaultTableCreator) CreateTable(dbConn *pgx.Conn, info *idrf.DataSet) error {
-	tableName := info.DataSetName
-	query := dataSetToSQLTableDef(tableName, info)
+	query := dataSetToSQLTableDef(info)
 	log.Printf("Creating table with:\n %s", query)
 
 	_, err := dbConn.Exec(query)
@@ -45,7 +44,7 @@ func (d *defaultTableCreator) CreateTable(dbConn *pgx.Conn, info *idrf.DataSet) 
 		return err
 	}
 
-	hypertableQuery := fmt.Sprintf(createHypertableQueryTemplate, tableName, info.TimeColumn)
+	hypertableQuery := fmt.Sprintf(createHypertableQueryTemplate, info.DataSetName, info.TimeColumn)
 	log.Printf("Creating hypertable with: %s", hypertableQuery)
 	_, err = dbConn.Exec(hypertableQuery)
 	if err != nil {
@@ -68,7 +67,7 @@ func (d *defaultTableCreator) CreateTimescaleExtension(dbConn *pgx.Conn) error {
 	return err
 }
 
-func dataSetToSQLTableDef(tableName string, dataSet *idrf.DataSet) string {
+func dataSetToSQLTableDef(dataSet *idrf.DataSet) string {
 	columnDefinitions := make([]string, len(dataSet.Columns))
 	for i, column := range dataSet.Columns {
 		dataType := idrfToPgType(column.DataType)
@@ -77,5 +76,5 @@ func dataSetToSQLTableDef(tableName string, dataSet *idrf.DataSet) string {
 
 	columnsString := strings.Join(columnDefinitions, ", ")
 
-	return fmt.Sprintf(createTableQueryTemplate, tableName, columnsString)
+	return fmt.Sprintf(createTableQueryTemplate, dataSet.DataSetName, columnsString)
 }

--- a/internal/schemamanagement/ts/table_creator_test.go
+++ b/internal/schemamanagement/ts/table_creator_test.go
@@ -1,0 +1,33 @@
+package ts
+
+import (
+	"testing"
+
+	"github.com/timescale/outflux/internal/idrf"
+)
+
+func TestDataSetToSQLTableDef(t *testing.T) {
+	singleCol := []*idrf.ColumnInfo{&idrf.ColumnInfo{Name: "col1", DataType: idrf.IDRFTimestamp}}
+	twoCols := []*idrf.ColumnInfo{singleCol[0], &idrf.ColumnInfo{Name: "col2", DataType: idrf.IDRFDouble}}
+	threeCols := []*idrf.ColumnInfo{
+		&idrf.ColumnInfo{Name: "col1", DataType: idrf.IDRFTimestamptz},
+		&idrf.ColumnInfo{Name: "col2", DataType: idrf.IDRFString},
+		&idrf.ColumnInfo{Name: "col 3", DataType: idrf.IDRFInteger64}}
+	ds1, _ := idrf.NewDataSet("ds1", singleCol, singleCol[0].Name)
+	ds2, _ := idrf.NewDataSet("ds2", twoCols, twoCols[0].Name)
+	ds3, _ := idrf.NewDataSet("ds 3", threeCols, threeCols[0].Name)
+	tcs := []struct {
+		ds       *idrf.DataSet
+		expected string
+	}{
+		{ds: ds1, expected: "CREATE TABLE \"ds1\"(\"col1\" TIMESTAMP)"},
+		{ds: ds2, expected: "CREATE TABLE \"ds2\"(\"col1\" TIMESTAMP, \"col2\" FLOAT)"},
+		{ds: ds3, expected: "CREATE TABLE \"ds 3\"(\"col1\" TIMESTAMPTZ, \"col2\" TEXT, \"col 3\" BIGINT)"},
+	}
+	for _, tc := range tcs {
+		query := dataSetToSQLTableDef(tc.ds)
+		if query != tc.expected {
+			t.Errorf("expected: %s\ngot: %s", tc.expected, query)
+		}
+	}
+}


### PR DESCRIPTION
Also  add test for idrf.DataSet to CREATE TABLE conversion