### PR TITLE
Fix bug that didn't honor output-schema flag

### DIFF
--- a/cmd/outflux/migrate_i_test.go
+++ b/cmd/outflux/migrate_i_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package main
 
 import (

--- a/cmd/outflux/migrate_i_test.go
+++ b/cmd/outflux/migrate_i_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package main
 
 import (
@@ -210,5 +208,74 @@ func TestMigrateFieldsAsJson(t *testing.T) {
 
 	if time.Before(start) || fieldsCol != "{\"field1\": 1}" {
 		t.Errorf("expected time > %v and fields={\"field1\": 1}\ngot: time %s, field1=%s", start, time, fieldsCol)
+	}
+}
+
+func TestMigrateRenameOutputSchema(t *testing.T) {
+	//prepare influx db
+	start := time.Now().UTC()
+	db := "test_rename_schema"
+	targetSchema := "some_schema"
+	measure := "test"
+	tag := "tag1"
+	field := "field1"
+	value := 1
+	tagValue := "1"
+	tags := map[string]string{tag: tagValue}
+	fieldValues := map[string]interface{}{field: value}
+	if err := testutils.DeleteTimescaleDb(db); err != nil {
+		t.Fatalf("could not delete if exists ts db: %v", err)
+	}
+	if err := testutils.PrepareServersForITest(db); err != nil {
+		t.Fatalf("could not prepare servers: %v", err)
+	}
+	if err := testutils.CreateTimescaleSchema(db, targetSchema); err != nil {
+		t.Fatalf("could not create target schema: %v", err)
+	}
+	defer testutils.ClearServersAfterITest(db)
+
+	err := testutils.CreateInfluxMeasure(db, measure, []*map[string]string{&tags}, []*map[string]interface{}{&fieldValues})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// run
+	connConf, config := defaultConfig(db, measure)
+	connConf.OutputSchema = targetSchema
+	config.TagsAsJSON = true
+	config.TagsCol = "tags"
+	appContext := initAppContext()
+	err = migrate(appContext, connConf, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// check
+	dbConn, err := testutils.OpenTSConn(db)
+	if err != nil {
+		t.Fatalf("could not open db conn: %v", err)
+	}
+	defer dbConn.Close()
+
+	rows, err := dbConn.Query(fmt.Sprintf("SELECT * FROM %s.%s", targetSchema, measure))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer rows.Close()
+	var time time.Time
+	var field1 int
+	var tagsCol string
+	if !rows.Next() {
+		t.Fatal("couldn't check state of TS DB")
+	}
+
+	err = rows.Scan(&time, &tagsCol, &field1)
+	if err != nil {
+		t.Fatal("couldn't check state of TS DB")
+	}
+
+	if time.Before(start) || field1 != value || tagsCol != "{\"tag1\": \"1\"}" {
+		t.Errorf("expected time > %v and field1=%d and tags={\"tag1\": \"1\"}\ngot: time %s, field1=%d, tags=%s", start, value, time, field1, tagsCol)
 	}
 }

--- a/internal/cli/pipe_service_create_transformers.go
+++ b/internal/cli/pipe_service_create_transformers.go
@@ -11,11 +11,11 @@ const (
 	transformerIDTemplate = "%s_transfomer_%s"
 )
 
-func (p *pipeService) createTransformers(pipeId string, infConn influx.Client, measure string, connConf *ConnectionConfig, conf *MigrationConfig) ([]transformation.Transformer, error) {
+func (p *pipeService) createTransformers(pipeID string, infConn influx.Client, measure string, connConf *ConnectionConfig, conf *MigrationConfig) ([]transformation.Transformer, error) {
 	transformers := []transformation.Transformer{}
 
 	if conf.TagsAsJSON {
-		id := fmt.Sprintf(transformerIDTemplate, pipeId, "tagsAsJSON")
+		id := fmt.Sprintf(transformerIDTemplate, pipeID, "tagsAsJSON")
 		tagsTransformer, err := p.transformerService.TagsAsJSON(infConn, id, connConf.InputDb, measure, conf.TagsCol)
 		if err != nil {
 			return nil, err
@@ -27,7 +27,7 @@ func (p *pipeService) createTransformers(pipeId string, infConn influx.Client, m
 	}
 
 	if conf.FieldsAsJSON {
-		id := fmt.Sprintf(transformerIDTemplate, pipeId, "fieldsAsJSON")
+		id := fmt.Sprintf(transformerIDTemplate, pipeID, "fieldsAsJSON")
 		fieldsTransformer, err := p.transformerService.FieldsAsJSON(infConn, id, connConf.InputDb, measure, conf.FieldsCol)
 		if err != nil {
 			return nil, err
@@ -35,5 +35,8 @@ func (p *pipeService) createTransformers(pipeId string, infConn influx.Client, m
 		transformers = append(transformers, fieldsTransformer)
 	}
 
+	id := fmt.Sprintf(transformerIDTemplate, pipeID, "renameOutputSchema")
+	outputSchemaTransformer := p.transformerService.RenameOutputSchema(id, connConf.OutputSchema)
+	transformers = append(transformers, outputSchemaTransformer)
 	return transformers, nil
 }

--- a/internal/cli/pipe_service_create_transformers_test.go
+++ b/internal/cli/pipe_service_create_transformers_test.go
@@ -1,0 +1,109 @@
+package cli
+
+import (
+	"fmt"
+	"testing"
+
+	influx "github.com/influxdata/influxdb/client/v2"
+	"github.com/timescale/outflux/internal/idrf"
+	"github.com/timescale/outflux/internal/transformation"
+)
+
+func TestCreateTransformers(t *testing.T) {
+	err := fmt.Errorf("error")
+	testCases := []struct {
+		desc             string
+		mock             *psctMockService
+		expectedTransIds []string
+		expectErr        bool
+		conf             *MigrationConfig
+		connConf         *ConnectionConfig
+	}{
+		{
+			desc:      "error on tags as json transformer",
+			mock:      &psctMockService{tagsErr: err},
+			conf:      &MigrationConfig{TagsAsJSON: true},
+			connConf:  &ConnectionConfig{},
+			expectErr: true,
+		}, {
+			desc: "error on fields as json transformer",
+			mock: &psctMockService{
+				fieldsErr: err,
+			},
+			conf:      &MigrationConfig{FieldsAsJSON: true},
+			connConf:  &ConnectionConfig{},
+			expectErr: true,
+		}, {
+			desc:             "tags transformer is nil, no tags for measure",
+			mock:             &psctMockService{renameT: &psctMockTrans{"r"}},
+			expectedTransIds: []string{"r"},
+			conf:             &MigrationConfig{TagsAsJSON: true},
+			connConf:         &ConnectionConfig{},
+		}, {
+			desc: "all transformers created",
+			mock: &psctMockService{
+				tagsT:   &psctMockTrans{id: "t"},
+				fieldsT: &psctMockTrans{id: "f"},
+				renameT: &psctMockTrans{id: "r"},
+			},
+			expectedTransIds: []string{"t", "f", "r"},
+			conf:             &MigrationConfig{FieldsAsJSON: true, TagsAsJSON: true},
+			connConf:         &ConnectionConfig{},
+		},
+	}
+	for _, tc := range testCases {
+		ps := &pipeService{
+			transformerService: tc.mock,
+		}
+
+		trans, err := ps.createTransformers("id", nil, "measure", tc.connConf, tc.conf)
+		if err == nil && tc.expectErr {
+			t.Fatalf("%s:expected error, none got", tc.desc)
+		} else if err != nil && !tc.expectErr {
+			t.Fatalf("%s: unexpected err: %v", tc.desc, err)
+		}
+
+		if tc.expectErr {
+			continue
+		}
+
+		if len(trans) != len(tc.expectedTransIds) {
+			t.Fatalf("%s: expected %d transformers, got %d", tc.desc, len(tc.expectedTransIds), len(trans))
+		}
+
+		for i, returnedTrans := range trans {
+			if returnedTrans.ID() != tc.expectedTransIds[i] {
+				t.Fatalf("%s: expected trans id '%s', got '%s'", tc.desc, returnedTrans.ID(), tc.expectedTransIds[i])
+			}
+		}
+	}
+}
+
+type psctMockService struct {
+	tagsT     transformation.Transformer
+	tagsErr   error
+	fieldsT   transformation.Transformer
+	fieldsErr error
+	renameT   transformation.Transformer
+}
+
+func (p *psctMockService) TagsAsJSON(infConn influx.Client, id, db, measure string, resultCol string) (transformation.Transformer, error) {
+	return p.tagsT, p.tagsErr
+}
+
+func (p *psctMockService) FieldsAsJSON(infConn influx.Client, id, db, measure string, resultCol string) (transformation.Transformer, error) {
+	return p.fieldsT, p.fieldsErr
+}
+func (p *psctMockService) RenameOutputSchema(id, outputSchema string) transformation.Transformer {
+	return p.renameT
+}
+
+type psctMockTrans struct {
+	id string
+}
+
+func (p *psctMockTrans) ID() string {
+	return p.id
+}
+func (p *psctMockTrans) Prepare(input *idrf.Bundle) (*idrf.Bundle, error) { return nil, nil }
+func (p *psctMockTrans) Start(chan error) error                           { return nil }

--- a/internal/cli/transformer_service.go
+++ b/internal/cli/transformer_service.go
@@ -9,12 +9,14 @@ import (
 	"github.com/timescale/outflux/internal/schemamanagement/influx/discovery"
 	"github.com/timescale/outflux/internal/transformation"
 	jsonCombiner "github.com/timescale/outflux/internal/transformation/jsoncombiner"
+	"github.com/timescale/outflux/internal/transformation/schemarenamer"
 )
 
 // TransformerService creates different transformers
 type TransformerService interface {
 	TagsAsJSON(infConn influx.Client, id, db, measure string, resultCol string) (transformation.Transformer, error)
 	FieldsAsJSON(infConn influx.Client, id, db, measure string, resultCol string) (transformation.Transformer, error)
+	RenameOutputSchema(id, outputSchema string) transformation.Transformer
 }
 
 // NewTransformerService creates a new implementation of the TransformerService interface
@@ -57,6 +59,10 @@ func (t *transformerService) FieldsAsJSON(infConn influx.Client, id, db, measure
 	}
 
 	return jsonCombiner.NewTransformer(id, fields, resultCol)
+}
+
+func (t *transformerService) RenameOutputSchema(id, outputSchema string) transformation.Transformer {
+	return schemarenamer.NewTransformer(id, outputSchema)
 }
 
 type fetchColumnsFn func() ([]*idrf.Column, error)

--- a/internal/idrf/data_set.go
+++ b/internal/idrf/data_set.go
@@ -78,3 +78,11 @@ func NewDataSet(dataSetName string, columns []*Column, timeColumn string) (*Data
 
 	return &DataSet{dataSetName, columns, timeColumn}, nil
 }
+
+// GenerateDataSetIdentifier combines a schema name and table name in a single data set identifier
+func GenerateDataSetIdentifier(schema, table string) string {
+	if schema != "" {
+		return schema + "." + table
+	}
+	return table
+}

--- a/internal/schemamanagement/ts/table_creator_i_test.go
+++ b/internal/schemamanagement/ts/table_creator_i_test.go
@@ -71,3 +71,61 @@ func TestCreateTable(t *testing.T) {
 		t.Error("table creation should have failed because table exists")
 	}
 }
+
+func TestCreateTableWithSchema(t *testing.T) {
+	db := "test_create_table_with_schema"
+	targetSchema := "some_schema"
+	if err := testutils.DeleteTimescaleDb(db); err != nil {
+		t.Fatalf("could not prepare db: %v", err)
+	}
+	if err := testutils.CreateTimescaleDb(db); err != nil {
+		t.Fatalf("could not prepare db: %v", err)
+	}
+	defer testutils.DeleteTimescaleDb(db)
+	if err := testutils.CreateTimescaleSchema(db, targetSchema); err != nil {
+		t.Fatalf("could not create target schema: %v", err)
+	}
+
+	dbConn, err := testutils.OpenTSConn(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dbConn.Close()
+	dataSet := &idrf.DataSet{
+		DataSetName: targetSchema + ".name",
+		Columns: []*idrf.Column{
+			&idrf.Column{Name: "col1", DataType: idrf.IDRFTimestamptz},
+			&idrf.Column{Name: "col2", DataType: idrf.IDRFInteger64},
+		},
+		TimeColumn: "col1",
+	}
+	creator := &defaultTableCreator{}
+	if err := creator.CreateTable(dbConn, dataSet); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	tableColumns := fmt.Sprintf(`SELECT column_name, data_type
+	FROM information_schema.columns
+	WHERE table_schema = %s AND table_name = %s`, "'"+targetSchema+"'", "'name'")
+	rows, err := dbConn.Query(tableColumns)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	currCol := 0
+	for rows.Next() {
+		var name, dataType string
+		colInfo := dataSet.Columns[currCol]
+		err = rows.Scan(&name, &dataType)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if colInfo.Name != name || colInfo.DataType != pgTypeToIdrf(dataType) {
+			t.Fatalf("Expected column name: %s and type %v\ngot: %s and %s", colInfo.Name, colInfo.DataType, name, dataType)
+		}
+		currCol++
+	}
+	if currCol == 0 {
+		t.Fatal("table wasn't created")
+	}
+}

--- a/internal/schemamanagement/ts/table_creator_test.go
+++ b/internal/schemamanagement/ts/table_creator_test.go
@@ -16,6 +16,7 @@ func TestDataSetToSQLTableDef(t *testing.T) {
 	ds1, _ := idrf.NewDataSet("ds1", singleCol, singleCol[0].Name)
 	ds2, _ := idrf.NewDataSet("ds2", twoCols, twoCols[0].Name)
 	ds3, _ := idrf.NewDataSet("ds 3", threeCols, threeCols[0].Name)
+	ds4, _ := idrf.NewDataSet("schema.ds4", singleCol, singleCol[0].Name)
 	tcs := []struct {
 		ds       *idrf.DataSet
 		expected string
@@ -23,6 +24,7 @@ func TestDataSetToSQLTableDef(t *testing.T) {
 		{ds: ds1, expected: "CREATE TABLE \"ds1\"(\"col1\" TIMESTAMP)"},
 		{ds: ds2, expected: "CREATE TABLE \"ds2\"(\"col1\" TIMESTAMP, \"col2\" FLOAT)"},
 		{ds: ds3, expected: "CREATE TABLE \"ds 3\"(\"col1\" TIMESTAMPTZ, \"col2\" TEXT, \"col 3\" BIGINT)"},
+		{ds: ds4, expected: "CREATE TABLE \"schema\".\"ds4\"(\"col1\" TIMESTAMP)"},
 	}
 	for _, tc := range tcs {
 		query := dataSetToSQLTableDef(tc.ds)

--- a/internal/testutils/server_preparation.go
+++ b/internal/testutils/server_preparation.go
@@ -86,13 +86,24 @@ func CreateInfluxMeasure(db, measure string, tags []*map[string]string, values [
 	return client.Write(bp)
 }
 
-// CreateTimescaleDb creates a new databas on the default server and then creates the extension on it
+// CreateTimescaleDb creates a new database on the default server and then creates the extension on it
 func CreateTimescaleDb(db string) error {
 	dbConn, err := OpenTSConn(defaultPgDb)
 	if err != nil {
 		return err
 	}
 	_, err = dbConn.Exec("CREATE DATABASE " + db)
+	dbConn.Close()
+	return err
+}
+
+// CreateTimescaleSchema creates a new schema in the specified db
+func CreateTimescaleSchema(db, schema string) error {
+	dbConn, err := OpenTSConn(db)
+	if err != nil {
+		return err
+	}
+	_, err = dbConn.Exec("CREATE SCHEMA " + schema)
 	dbConn.Close()
 	return err
 }

--- a/internal/transformation/schemarenamer/transformer.go
+++ b/internal/transformation/schemarenamer/transformer.go
@@ -1,0 +1,55 @@
+package schemarenamer
+
+import (
+	"fmt"
+
+	"github.com/timescale/outflux/internal/idrf"
+)
+
+// Transformer will hold the implementation for the schema-rename transformer.
+type Transformer struct {
+	id            string
+	outputSchema  string
+	prepareCalled bool
+}
+
+// NewTransformer returns a new instance of a transformer renames the schema
+// of a DataSet ("schema.table"->"schema1.table" or "table"-> "schema1.table")
+func NewTransformer(id string, outputSchema string) *Transformer {
+	return &Transformer{id: id, outputSchema: outputSchema}
+}
+
+// ID returns a string that identifies the transformer instance
+func (c *Transformer) ID() string {
+	return c.id
+}
+
+// Prepare verifies that the transformation can be executed, creates the output channel
+// and the transformed data set definition and returns them as a idrf.Bundle
+func (c *Transformer) Prepare(input *idrf.Bundle) (*idrf.Bundle, error) {
+	originDataSet := input.DataDef
+	_, table := originDataSet.SchemaAndTable()
+	newDataSetName := idrf.GenerateDataSetIdentifier(c.outputSchema, table)
+	newDataSet, err := idrf.NewDataSet(newDataSetName, originDataSet.Columns, originDataSet.TimeColumn)
+	if err != nil {
+		return nil, fmt.Errorf("%s: could not prepare schema renaming.\n%v", c.id, err)
+	}
+
+	// the data doesn't change, only the name of the resulting data set
+	// so the data channel is left as is
+	c.prepareCalled = true
+	return &idrf.Bundle{
+		DataDef:  newDataSet,
+		DataChan: input.DataChan,
+	}, nil
+}
+
+// Start doesn't do anything in this transformer since the data is not transformed,
+// only the schema (already done in Prepare)
+func (c *Transformer) Start(errChan chan error) error {
+	if !c.prepareCalled {
+		return fmt.Errorf("%s: Prepare must be called before Start", c.id)
+	}
+
+	return nil
+}

--- a/internal/transformation/schemarenamer/transformer_test.go
+++ b/internal/transformation/schemarenamer/transformer_test.go
@@ -78,11 +78,11 @@ func TestStart(t *testing.T) {
 	}
 	outBundle, err := trans.Prepare(inBundle)
 	if err != nil {
-		t.Fatalf("unpexpected error on prepare: %v", err)
+		t.Fatalf("unexpected error on prepare: %v", err)
 	}
 	err = trans.Start(make(chan error))
 	if err != nil {
-		t.Fatalf("unepxpected error on Start: %v", err)
+		t.Fatalf("unexpected error on Start: %v", err)
 	}
 
 	// will close output bundle channel

--- a/internal/transformation/schemarenamer/transformer_test.go
+++ b/internal/transformation/schemarenamer/transformer_test.go
@@ -1,0 +1,94 @@
+package schemarenamer
+
+import (
+	"testing"
+
+	"github.com/timescale/outflux/internal/idrf"
+)
+
+func TestNewTransformer(t *testing.T) {
+	trans := NewTransformer("id", "output")
+	if trans == nil {
+		t.Fatal("could not create transformer")
+	} else if trans.id != "id" || trans.outputSchema != "output" || trans.prepareCalled {
+		t.Fatalf("transformer should have id: id, outputSchema: output and prepareCalled: false\ngot: %v", trans)
+	}
+}
+
+func TestPrepare(t *testing.T) {
+	testCases := []struct {
+		inName       string
+		newSchema    string
+		expectedName string
+	}{
+		{inName: "table", newSchema: "schema", expectedName: "schema.table"},
+		{inName: "schema.table", newSchema: "schema", expectedName: "schema.table"},
+		{inName: "schema1.table", newSchema: "schema", expectedName: "schema.table"},
+		{inName: "one.two.three", newSchema: "four", expectedName: "four.two.three"},
+		{inName: "schema.table+smt", newSchema: "schema2", expectedName: "schema2.table+smt"},
+	}
+
+	timeCol := "time"
+	columns := []*idrf.Column{
+		&idrf.Column{Name: timeCol, DataType: idrf.IDRFTimestamp},
+		&idrf.Column{Name: "col", DataType: idrf.IDRFBoolean},
+	}
+	for _, testCase := range testCases {
+		ds, _ := idrf.NewDataSet(testCase.inName, columns, timeCol)
+		trans := NewTransformer("id", testCase.newSchema)
+		inDataChan := make(chan idrf.Row, 1)
+		resBundle, err := trans.Prepare(&idrf.Bundle{DataChan: inDataChan, DataDef: ds})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if !trans.prepareCalled {
+			t.Fatalf("expected prepareCalled to be true, wasn't")
+		}
+
+		if resBundle.DataDef.DataSetName != testCase.expectedName {
+			t.Fatalf("expected: %s, got: %s", testCase.expectedName, resBundle.DataDef.DataSetName)
+		}
+
+		// channel should be the same, msg sent to inDataChan
+		// should come out of resBundle.DataChan
+		inDataChan <- []interface{}{"1"}
+		got := <-resBundle.DataChan
+		if got[0].(string) != "1" {
+			t.Fatalf("unexpected data received. expected '1', got: %v", got[0])
+		}
+	}
+}
+
+func TestStart(t *testing.T) {
+	trans := NewTransformer("id", "schema")
+	if trans.Start(nil) == nil {
+		t.Fatal("prepare not called. expected error, none got")
+	}
+
+	timeCol := "time"
+	columns := []*idrf.Column{
+		&idrf.Column{Name: timeCol, DataType: idrf.IDRFTimestamp},
+		&idrf.Column{Name: "col", DataType: idrf.IDRFBoolean},
+	}
+	ds, _ := idrf.NewDataSet("ds", columns, timeCol)
+	inBundle := &idrf.Bundle{
+		DataChan: make(chan idrf.Row, 1),
+		DataDef:  ds,
+	}
+	outBundle, err := trans.Prepare(inBundle)
+	if err != nil {
+		t.Fatalf("unpexpected error on prepare: %v", err)
+	}
+	err = trans.Start(make(chan error))
+	if err != nil {
+		t.Fatalf("unepxpected error on Start: %v", err)
+	}
+
+	// will close output bundle channel
+	// no data should have been sent to it
+	close(outBundle.DataChan)
+	for range outBundle.DataChan {
+		t.Fatalf("unexpected data received on channel")
+	}
+}


### PR DESCRIPTION
When refactoring the internals in order to introduce
Transformers, the code that migrated the data to a 
specified schema was removed, because it wen't against
the new design of the execution pipelines. This PR introduces the
ability to rename the output schema again, as a new Transformer 
which does only schema transformation in the Prepare step.
No additional overhead is introduced