### PR TITLE
Add compatibility tests for different Influx versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,19 +3,90 @@ language: go
 services:
   - docker
 
-go:
-  - 1.10.x
-  - 1.11.x
-
-before_install:
-  # Setup dependency management tool
-  - curl -L -s https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64 -o $GOPATH/bin/dep
-  - chmod +x $GOPATH/bin/dep
-  - dep ensure
-  # Start influxdb timescale in docker
-  - docker run -d --name influx1 -p 8086:8086 influxdb
-  - docker run -d --name ts1 -p 5433:5432 -e POSTGRES_PASSWORD=postgres timescale/timescaledb
-
-script:
-  # Unit tests
-  - go test -race -tags=integration -v ./...
+jobs:
+  include:
+    - stage: test
+      name: "Influx compat 1.0"
+      go:
+        - 1.11.x
+      before_install:
+        # Start timescale in docker
+        - docker run -d --name ts1 -p 5433:5432 -e POSTGRES_PASSWORD=postgres timescale/timescaledb
+        # Run specific version of influx
+        - docker run -d --name influx1_0 -p 8086:8086 influxdb:1.0
+      install:
+        # Setup dependency management tool
+        - curl -L -s https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64 -o $GOPATH/bin/dep
+        - chmod +x $GOPATH/bin/dep
+        - dep ensure
+      script:
+        # Unit and integration tests
+        - go test -race -tags=integration -v ./...
+    - stage: test
+      name: "Influx compat 1.5"
+      go:
+        - 1.11.x
+      before_install:
+        # Start timescale in docker
+        - docker run -d --name ts1 -p 5433:5432 -e POSTGRES_PASSWORD=postgres timescale/timescaledb
+        # Run specific version of influx
+        - docker run -d --name influx1_5 -p 8086:8086 influxdb:1.5
+      install:
+        # Setup dependency management tool
+        - curl -L -s https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64 -o $GOPATH/bin/dep
+        - chmod +x $GOPATH/bin/dep
+        - dep ensure
+      script:
+        # Unit and integration tests
+        - go test -race -tags=integration -v ./...
+    - stage: test
+      name: "Influx compat 1.6"
+      go:
+        - 1.11.x
+      before_install:
+        # Start timescale in docker
+        - docker run -d --name ts1 -p 5433:5432 -e POSTGRES_PASSWORD=postgres timescale/timescaledb
+        # Run specific version of influx
+        - docker run -d --name influx1_6 -p 8086:8086 influxdb:1.6
+      install:
+        # Setup dependency management tool
+        - curl -L -s https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64 -o $GOPATH/bin/dep
+        - chmod +x $GOPATH/bin/dep
+        - dep ensure
+      script:
+        # Unit and integration tests
+        - go test -race -tags=integration -v ./...
+    - stage: test
+      name: "Influx compat 1.7"
+      go:
+        - 1.11.x
+      before_install:
+        # Start timescale in docker
+        - docker run -d --name ts1 -p 5433:5432 -e POSTGRES_PASSWORD=postgres timescale/timescaledb
+        # Run specific version of influx
+        - docker run -d --name influx1_7 -p 8086:8086 influxdb:1.7
+      install:
+        # Setup dependency management tool
+        - curl -L -s https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64 -o $GOPATH/bin/dep
+        - chmod +x $GOPATH/bin/dep
+        - dep ensure
+      script:
+        # Unit and integration tests
+        - go test -race -tags=integration -v ./...
+    - stage: test
+      name: "Influx compat latest"
+      go:
+        - 1.11.x
+      before_install:
+        # Start timescale in docker
+        - docker run -d --name ts1 -p 5433:5432 -e POSTGRES_PASSWORD=postgres timescale/timescaledb
+        # Run specific version of influx
+        - docker run -d --name influx_l -p 8086:8086 influxdb
+      install:
+         # Setup dependency management tool
+        - curl -L -s https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64 -o $GOPATH/bin/dep
+        - chmod +x $GOPATH/bin/dep
+        - dep ensure 
+      script:
+        # Unit and integration tests
+        - go test -race -tags=integration -v ./...

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This repo contains code for exporting complete InfluxDB databases or selected me
 
 ## Installation
 
+### Installing from source
+
 Outflux is a Go project managed by `dep` (The go dependency management tool). To download the proper dependency versions, `dep` must be installed on your system. Instructions can be found on the [official documentation page](https://golang.github.io/dep/docs/installation.html). 
 
 ```bash
@@ -21,13 +23,22 @@ $ cd cmd/outlux
 $ go install 
 ```
 
+### Binary releases
+We upload prepackaged binaries available for GNU/Linux, Windows and MacOS in the [releases](https://github.com/timescale/outflux/releases).
+Just download the binary, extract the compressed tarball and run the executable
+
 ## How to use
+
+Outflux supports InfluxDB versions 1.0 and upwards. We explicitly test for compatibility for versions 1.0, 1.5, 1.6, 1.7 and the `latest` tag of the InfluxDB docker container.
 
 ### Before using it
 
-It is recommended that you have some InfluxDB database with some data. For testing purposes you can check out the [TSBS Data Loader Tool](https://github.com/timescale/tsbs) part of the Time Series Benchmark Suite. It can generate large ammounts of data for and load them in influx. Data can be generated with [one command](https://github.com/timescale/tsbs#data-generation), just specify the format as 'influx', and them load it in with [another command](https://github.com/timescale/tsbs#data-generation).
+It is recommended that you have some InfluxDB database with some data. 
+For testing purposes you can check out the [TSBS Data Loader Tool](https://github.com/timescale/tsbs) part of the Time Series Benchmark Suite. 
+It can generate large ammounts of data for and load them in influx. 
+Data can be generated with [one command](https://github.com/timescale/tsbs#data-generation), just specify the format as 'influx', and then load it in with [another command](https://github.com/timescale/tsbs#data-generation).
 
-### !Connection params!
+### ⚠️ Connection params ⚠️
 Detailed information about how to pass the connection parameters to Outflux can be found at the bottom of this document at the [Connection](section)
 
 


### PR DESCRIPTION
Configure Travis to execute multiple stages. Each stage runs an
Influx container of a different version and runs the tests

I had trouble enabling the stages to run for both go 1.11 and go 1.10, they always ran with one version.
When I pulled them out of the `jobs` tag a job with a default `go test` command was run