### PR TITLE
Fix the bug with handling measures with spaces and tics

### DIFF
--- a/internal/schemamanagement/influx/discovery/tag_discovery.go
+++ b/internal/schemamanagement/influx/discovery/tag_discovery.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	showTagsQueryTemplate = "SHOW TAG KEYS FROM %s"
+	showTagsQueryTemplate = "SHOW TAG KEYS FROM \"%s\""
 )
 
 // TagExplorer Defines an API for discovering the tags of an InfluxDB measurement


### PR DESCRIPTION
As reported in #46 when a measure contains a space or a tick in the name, Outflux could not discover the available tags because of a bug in the SHOW query. This PR fixes the issue by escaping the measure name properly.