### PR TITLE
Add support for InfluxDB retention policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ $ cd $GOPATH/bin/
 $ ./outflux schema-transfer --help
 ```
 
-Usage of the is `outflux schema-transfer database [measure1 measure2 ...] [flags]`. Where database is the name of the InfluxDB database you wish to export. `[measure1 ...] ` are optional and if specified will export only those measurements from the selected database.
+Usage of the is `outflux schema-transfer database [measure1 measure2 ...] [flags]`. Where database is the name of the InfluxDB database you wish to export. `[measure1 ...] ` are optional and if specified will export only those measurements from the selected database. 
+Additionally you can specify the retention policy as `retention_policy.measure` or `"retention-policy"."measure name"` if some of the identifiers contain a space or dash.
+⚠️ *The resulting target table will be named `"retention_policy.measure"` in TimescaleDB*
 
 For example `outflux schema-transfer benchmark cpu mem` will discover the schema for the `cpu` and `mem` measurements from the `benchmark` database.
 
@@ -133,9 +135,10 @@ $ outflux migrate benchmark \
 > --output-conn='dbname=targetdb user=test password=test' \
 ```
 
-* Export only measurement 'cpu' from the 'benchmark' drop the existing 'cpu' table in 'targetdb' if exists, create if not
+* Export only measurement 'cpu' from 'two_week' retention policy in the 'benchmark' database. 
+Drop the existing '"two_week.cpu"' table in 'targetdb' if exists, create if not
 ```bash
-$ outflux migrate benchmark cpu \
+$ outflux migrate benchmark two_week.cpu \
 > --input-user=test \
 > --input-pass=test \
 > --output-con='dbname=targetdb user=test pass=test'\

--- a/cmd/outflux/migrate_i_test.go
+++ b/cmd/outflux/migrate_i_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package main
 
 import (
@@ -260,6 +258,80 @@ func TestMigrateRenameOutputSchema(t *testing.T) {
 	defer dbConn.Close()
 
 	rows, err := dbConn.Query(fmt.Sprintf("SELECT * FROM %s.%s", targetSchema, measure))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer rows.Close()
+	var time time.Time
+	var field1 int
+	var tagsCol string
+	if !rows.Next() {
+		t.Fatal("couldn't check state of TS DB")
+	}
+
+	err = rows.Scan(&time, &tagsCol, &field1)
+	if err != nil {
+		t.Fatal("couldn't check state of TS DB")
+	}
+
+	if time.Before(start) || field1 != value || tagsCol != "{\"tag1\": \"1\"}" {
+		t.Errorf("expected time > %v and field1=%d and tags={\"tag1\": \"1\"}\ngot: time %s, field1=%d, tags=%s", start, value, time, field1, tagsCol)
+	}
+}
+
+func TestMigrateRetentionPolicy(t *testing.T) {
+	//prepare influx db
+	start := time.Now().UTC()
+	db := "test_rp"
+	targetSchema := "some_schema"
+	rp := "rp"
+	measure := "test measure"
+	tag := "tag1"
+	field := "field1"
+	value := 1
+	tagValue := "1"
+	tags := map[string]string{tag: tagValue}
+	fieldValues := map[string]interface{}{field: value}
+	if err := testutils.DeleteTimescaleDb(db); err != nil {
+		t.Fatalf("could not delete if exists ts db: %v", err)
+	}
+	if err := testutils.PrepareServersForITest(db); err != nil {
+		t.Fatalf("could not prepare servers: %v", err)
+	}
+	if err := testutils.CreateTimescaleSchema(db, targetSchema); err != nil {
+		t.Fatalf("could not create target schema: %v", err)
+	}
+	defer testutils.ClearServersAfterITest(db)
+
+	err := testutils.CreateInfluxRP(db, rp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = testutils.CreateInfluxMeasureWithRP(db, rp, measure, []*map[string]string{&tags}, []*map[string]interface{}{&fieldValues})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// run
+	connConf, config := defaultConfig(db, rp+"."+measure)
+	connConf.OutputSchema = targetSchema
+	config.TagsAsJSON = true
+	config.TagsCol = "tags"
+	appContext := initAppContext()
+	err = migrate(appContext, connConf, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// check
+	dbConn, err := testutils.OpenTSConn(db)
+	if err != nil {
+		t.Fatalf("could not open db conn: %v", err)
+	}
+	defer dbConn.Close()
+
+	rows, err := dbConn.Query(fmt.Sprintf(`SELECT * FROM %s."%s"`, targetSchema, measure))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/extraction/influx/query_building_test.go
+++ b/internal/extraction/influx/query_building_test.go
@@ -1,0 +1,97 @@
+package influx
+
+import (
+	"testing"
+
+	"github.com/timescale/outflux/internal/extraction/config"
+	"github.com/timescale/outflux/internal/idrf"
+)
+
+func TestBuildMeasurementName(t *testing.T) {
+	testCases := []struct {
+		in  string
+		exp string
+	}{
+		{in: "measure", exp: `"measure"`},
+		{in: "rp.measure", exp: `"rp"."measure"`},
+		{in: "rp.measure name", exp: `"rp"."measure name"`},
+		{in: "rp name.measure.name", exp: `"rp name"."measure.name"`},
+	}
+
+	for _, tc := range testCases {
+		out := buildMeasurementName(tc.in)
+		if out != tc.exp {
+			t.Errorf("expected: %s, got: %s", tc.exp, out)
+		}
+	}
+}
+
+func TestBuildProjection(t *testing.T) {
+	testCases := []struct {
+		in  []*idrf.Column
+		exp string
+	}{
+		{in: []*idrf.Column{{Name: "col1"}}, exp: `"col1"`},
+		{in: []*idrf.Column{{Name: "col 1"}}, exp: `"col 1"`},
+		{in: []*idrf.Column{{Name: "col 1"}, {Name: "col 2"}}, exp: `"col 1", "col 2"`},
+	}
+
+	for _, tc := range testCases {
+		out := buildProjection(tc.in)
+		if out != tc.exp {
+			t.Errorf("expected: %s, got: %s", tc.exp, out)
+		}
+	}
+}
+
+func TestBuildSelectCommand(t *testing.T) {
+	testCases := []struct {
+		measure string
+		columns []*idrf.Column
+		from    string
+		to      string
+		limit   uint64
+		exp     string
+	}{
+		{
+			measure: "m",
+			columns: []*idrf.Column{{Name: "col1"}},
+			exp:     `SELECT "col1" FROM "m"`,
+		}, {
+			measure: "rp.m",
+			columns: []*idrf.Column{{Name: "col1"}, {Name: "col 2"}},
+			from:    "a",
+			exp:     `SELECT "col1", "col 2" FROM "rp"."m" WHERE time >= 'a'`,
+		}, {
+			measure: "m",
+			columns: []*idrf.Column{{Name: "col1"}},
+			to:      "b",
+			exp:     `SELECT "col1" FROM "m" WHERE time <= 'b'`,
+		}, {
+			measure: "m",
+			columns: []*idrf.Column{{Name: "col1"}},
+			from:    "a",
+			to:      "b",
+			exp:     `SELECT "col1" FROM "m" WHERE time >= 'a' AND time <= 'b'`,
+		}, {
+			measure: "m",
+			columns: []*idrf.Column{{Name: "col1"}},
+			limit:   11,
+			exp:     `SELECT "col1" FROM "m" LIMIT 11`,
+		},
+	}
+
+	for _, tc := range testCases {
+		config := &config.MeasureExtraction{
+			Measure: tc.measure,
+			From:    tc.from,
+			To:      tc.to,
+			Limit:   tc.limit,
+		}
+
+		out := buildSelectCommand(config, tc.columns)
+		if out != tc.exp {
+			t.Errorf("expected: %s, got: %s", tc.exp, out)
+		}
+	}
+}

--- a/internal/schemamanagement/influx/discovery/field_discovery_test.go
+++ b/internal/schemamanagement/influx/discovery/field_discovery_test.go
@@ -77,3 +77,42 @@ func TestDiscoverMeasurementFields(t *testing.T) {
 		}
 	}
 }
+
+func TestDiscoverMeasurementFieldsWithRP(t *testing.T) {
+	var mockClient influx.Client
+	mockClient = &influxqueries.MockClient{}
+	database := "database"
+	measure := "rp.measure"
+
+	cases := []testCase{
+		{
+			showQueryResult: &influxqueries.InfluxShowResult{ // proper result
+				Values: [][]string{{"1", "boolean"}},
+			},
+			expectedTags: []*idrf.Column{
+				{Name: "1", DataType: idrf.IDRFBoolean},
+			},
+		},
+	}
+
+	for _, testCase := range cases {
+		fieldExplorer := defaultFieldExplorer{
+			queryService: mock(testCase),
+		}
+		result, err := fieldExplorer.DiscoverMeasurementFields(mockClient, database, measure)
+		if err != nil {
+			t.Errorf("unexpected error %v", err)
+		}
+
+		expected := testCase.expectedTags
+		if len(expected) != len(result) {
+			t.Errorf("еxpected result: '%v', got '%v'", expected, result)
+		}
+
+		for index, resColumn := range result {
+			if resColumn.Name != expected[index].Name || resColumn.DataType != expected[index].DataType {
+				t.Errorf("Expected column: %v, got %v", expected[index], resColumn)
+			}
+		}
+	}
+}

--- a/internal/schemamanagement/influx/discovery/tag_discovery_test.go
+++ b/internal/schemamanagement/influx/discovery/tag_discovery_test.go
@@ -86,9 +86,10 @@ func TestFetchMeasurementsShowTagsQuery(t *testing.T) {
 		measure       string
 		db            string
 	}{
-		{expectedQuery: `SHOW TAG KEYS FROM "measure"`,
-			measure: "measure",
-			db:      "db",
+		{
+			expectedQuery: `SHOW TAG KEYS FROM "measure"`,
+			measure:       "measure",
+			db:            "db",
 		}, {
 			expectedQuery: `SHOW TAG KEYS FROM "measure 1"`,
 			measure:       "measure 1",
@@ -96,6 +97,10 @@ func TestFetchMeasurementsShowTagsQuery(t *testing.T) {
 		}, {
 			expectedQuery: `SHOW TAG KEYS FROM "measure-2"`,
 			measure:       "measure-2",
+			db:            "db",
+		}, {
+			expectedQuery: `SHOW TAG KEYS FROM "rp"."measure-2"`,
+			measure:       "rp.measure-2",
 			db:            "db",
 		},
 	}

--- a/internal/schemamanagement/influx/influx_schema_manager.go
+++ b/internal/schemamanagement/influx/influx_schema_manager.go
@@ -39,23 +39,6 @@ func (sm *SchemaManager) DiscoverDataSets() ([]string, error) {
 // FetchDataSet for a given data set identifier (retention.measureName, or just measureName)
 // returns the idrf.DataSet describing it
 func (sm *SchemaManager) FetchDataSet(dataSetIdentifier string) (*idrf.DataSet, error) {
-	measurements, err := sm.measureExplorer.FetchAvailableMeasurements(sm.influxClient, sm.database)
-	if err != nil {
-		return nil, fmt.Errorf("could not fetch available measurements from InfluxDB\n%v", err)
-	}
-
-	measureMissing := true
-	for _, returnedMeasure := range measurements {
-		if returnedMeasure == dataSetIdentifier {
-			measureMissing = false
-			break
-		}
-	}
-
-	if measureMissing {
-		return nil, fmt.Errorf("measure '%s' not found in database '%s'", dataSetIdentifier, sm.database)
-	}
-
 	return sm.dataSetConstructor.construct(dataSetIdentifier)
 }
 

--- a/internal/schemamanagement/influx/influx_schema_manager_test.go
+++ b/internal/schemamanagement/influx/influx_schema_manager_test.go
@@ -40,7 +40,6 @@ func TestDiscoverDataSets(t *testing.T) {
 func TestFetchDataSet(t *testing.T) {
 	// Given mock values used in the test cases
 	genericError := fmt.Errorf("generic error")
-	badMeasure := "b"
 	goodMeasure := "a"
 	measures := []string{goodMeasure}
 	dataSet := &idrf.DataSet{DataSetName: goodMeasure}
@@ -54,8 +53,6 @@ func TestFetchDataSet(t *testing.T) {
 		dsErr      error
 		ds         *idrf.DataSet
 	}{
-		{desc: "error discovering measures", expectErr: true, msErr: genericError},
-		{desc: "requested measure is missing", expectErr: true, measures: measures, reqMeasure: badMeasure},
 		{desc: "error constructing data set", expectErr: true, measures: measures, reqMeasure: goodMeasure, dsErr: genericError},
 		{desc: "good data set", measures: measures, reqMeasure: goodMeasure, ds: dataSet},
 	}


### PR DESCRIPTION
Because of the behaviour of the InfluxDB query
'SHOW MEASUREMENTS' where it is not specified which measurements
belong to which retention policy, it was impossible to extract
a measure from other than the default RP. This commit removes a
redundant check for the presence of a measurement when doing
migration of a single measurement and modifies the generated
influx queries for schema exploration in order to properly select
a measurement in a specified RP. Passing the name of the measurement
as "retention_policy"."measurement name" now exports the proper data