### PR TITLE
quote table name to prevent pg's auto lowercase convert

### DIFF
--- a/internal/schemamanagement/ts/table_dropper.go
+++ b/internal/schemamanagement/ts/table_dropper.go
@@ -8,8 +8,8 @@ import (
 )
 
 const (
-	dropTableQueryTemplate        = "DROP TABLE %s"
-	dropTableCascadeQueryTemplate = "DROP TABLE %s CASCADE"
+	dropTableQueryTemplate        = "DROP TABLE \"%s\""
+	dropTableCascadeQueryTemplate = "DROP TABLE \"%s\" CASCADE"
 )
 
 type tableDropper interface {


### PR DESCRIPTION
PostgreSQL converts all table column names into lowercase, unless quoted. 
This commit aims to fix the problem when measurement's name include uppercase or underscore etc.