### PR TITLE
Change the behaviour on TimescaleDB metadata update fail

### DIFF
--- a/internal/schemamanagement/ts/ts_schema_manager.go
+++ b/internal/schemamanagement/ts/ts_schema_manager.go
@@ -65,7 +65,8 @@ func (sm *TSSchemaManager) PrepareDataSet(dataSet *idrf.DataSet, strategy schema
 		return preparationError
 	}
 
-	return sm.updateMetadata()
+	sm.updateMetadata()
+	return nil
 }
 
 func (sm *TSSchemaManager) validateOnly(dataSet *idrf.DataSet, tableExists bool) error {
@@ -178,15 +179,22 @@ func (sm *TSSchemaManager) validatePartitioning(dataSet *idrf.DataSet) error {
 	return nil
 }
 
-func (sm *TSSchemaManager) updateMetadata() error {
+func (sm *TSSchemaManager) updateMetadata() {
 	metadataTableName, err := sm.explorer.metadataTableName(sm.dbConn)
 	if err != nil {
-		return fmt.Errorf("could not check existance of installation metadata table. %v", err)
-	}
-	if metadataTableName == "" {
-		log.Println("Installation metadata table doesn't exist in existing TimescaleDB version")
-		return nil
+		log.Println("could not check for the existence of the timescale metadata table")
+		log.Println("reason: " + err.Error())
+		return
 	}
 
-	return sm.creator.UpdateMetadata(sm.dbConn, metadataTableName)
+	if metadataTableName == "" {
+		log.Println("Installation metadata table doesn't exist in this TimescaleDB version")
+		return
+	}
+
+	err = sm.creator.UpdateMetadata(sm.dbConn, metadataTableName)
+	if err != nil {
+		log.Println("could not update TimescaleDB metadata")
+		log.Println("reason:" + err.Error())
+	}
 }

--- a/internal/schemamanagement/ts/ts_schema_manager_test.go
+++ b/internal/schemamanagement/ts/ts_schema_manager_test.go
@@ -99,11 +99,6 @@ func TestPrepareDataSetFails(t *testing.T) {
 			args:     prepareArgs{DataSet: dataSet, Strategy: schemaconfig.ValidateOnly},
 			explorer: notPartitionedProperly(existingColumns),
 			desc:     "validate only, compatible, is hypertable, partitioned by another column",
-		}, {
-			args:     prepareArgs{DataSet: dataSet, Strategy: schemaconfig.ValidateOnly},
-			explorer: properMock(existingColumns),
-			creator:  errorOnMetadataUpdate(existingColumns),
-			desc:     "validate only, compatible, is hyper, partitioned properly, error on updating metadata",
 		},
 	}
 
@@ -163,6 +158,12 @@ func TestPrepareOk(t *testing.T) {
 			explorer: properMockForCreateIfMissing(existingColumns),
 			creator:  okOnTableCreate(),
 			desc:     "validate not called if need to create",
+		},
+		{
+			args:     prepareArgs{DataSet: dataSet, Strategy: schemaconfig.ValidateOnly},
+			explorer: properMock(existingColumns),
+			creator:  errorOnMetadataUpdate(existingColumns),
+			desc:     "error on updating metadata",
 		},
 	}
 


### PR DESCRIPTION
Metadata update may fail because of lack of permissions
to read and write to the installation_metadata or
telemetry_metadata table. This shouldn't cause Outflux to
abort and fail.