### PR TITLE
Add flag to skip HTTPS verification for Influx connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,19 +61,20 @@ For example `outflux schema-transfer benchmark cpu mem` will discover the schema
 
 Available flags for schema-transfer are:
 
-| flag             | type    | default               | description |
-|------------------|---------|-----------------------|-------------|
-| input-server     | string  | http://localhost:8086 | Location of the input database, http(s)://location:port. |
-| input-pass       | string  |                       | Password to use when connecting to the input database |
-| input-user       | string  |                       | Username to use when connecting to the input database |
-| output-conn      | string  | sslmode=disable       | Connection string to use to connect to the output database|
-| output-schema    | string  |                       | The schema of the output database that the data will be inserted into |
-| schema-strategy  | string  | CreateIfMissing       | Strategy to use for preparing the schema of the output database. Valid options: ValidateOnly, CreateIfMissing, DropAndCreate, DropCascadeAndCreate |
-| tags-as-json     | bool    | false                 | If this flag is set to true, then the Tags of the influx measures being exported will be combined into a single JSONb column in Timescale |
-| tags-column      | string  | tags                  | When `tags-as-json` is set, this column specifies the name of the JSON column for the tags |
-| fields-as-json   | bool    | false                 | If this flag is set to true, then the Fields of the influx measures being exported will be combined into a single JSONb column in Timescale |
-| fields-column    | string  | fields                | When `fields-as-json` is set, this column specifies the name of the JSON column for the fields |
-| quiet            | bool    | false                 | If specified will suppress any log to STDOUT |
+| flag               | type    | default               | description |
+|--------------------|---------|-----------------------|-------------|
+| input-server       | string  | http://localhost:8086 | Location of the input database, http(s)://location:port. |
+| input-pass         | string  |                       | Password to use when connecting to the input database |
+| input-user         | string  |                       | Username to use when connecting to the input database |
+| input-unsafe-https | bool    | false                 | Should 'InsecureSkipVerify' be passed to the input connection |
+| output-conn        | string  | sslmode=disable       | Connection string to use to connect to the output database|
+| output-schema      | string  |                       | The schema of the output database that the data will be inserted into |
+| schema-strategy    | string  | CreateIfMissing       | Strategy to use for preparing the schema of the output database. Valid options: ValidateOnly, CreateIfMissing, DropAndCreate, DropCascadeAndCreate |
+| tags-as-json       | bool    | false                 | If this flag is set to true, then the Tags of the influx measures being exported will be combined into a single JSONb column in Timescale |
+| tags-column        | string  | tags                  | When `tags-as-json` is set, this column specifies the name of the JSON column for the tags |
+| fields-as-json     | bool    | false                 | If this flag is set to true, then the Fields of the influx measures being exported will be combined into a single JSONb column in Timescale |
+| fields-column      | string  | fields                | When `fields-as-json` is set, this column specifies the name of the JSON column for the fields |
+| quiet              | bool    | false                 | If specified will suppress any log to STDOUT |
 
 ### Migrate
 
@@ -95,6 +96,7 @@ Available flags are:
 | input-server               | string  | http://localhost:8086 | Location of the input database, http(s)://location:port. |
 | input-pass                 | string  |                       | Password to use when connecting to the input database |
 | input-user                 | string  |                       | Username to use when connecting to the input database |
+| input-unsafe-https         | bool    | false                 | Should 'InsecureSkipVerify' be passed to the input connection |
 | limit                      | uint64  | 0                     | If specified will limit the export points to its value. 0 = NO LIMIT |
 | from                       | string  |                       | If specified will export data with a timestamp >= of its value. Accepted format: RFC3339 |
 | to                         | string  |                       | If specified will export data with a timestamp <= of its value. Accepted format: RFC3339 |
@@ -173,3 +175,5 @@ The connection parameters to the InfluxDB instance can be passed also through fl
 These are the same environment variables that the InfluxDB CLI uses. 
 
 If they are not set, or if you wish to override them, you can do so with the `--input-user` and `--input-pass`. 
+Also you can specify to Outflux to skip HTTPS verification when communicating with the InfluxDB server by setting the 
+`--input-unsafe-https` flag to `true`. 

--- a/cmd/outflux/migrate.go
+++ b/cmd/outflux/migrate.go
@@ -174,9 +174,10 @@ func openConnections(app *appContext, connArgs *cli.ConnectionConfig) (influx.Cl
 
 func influxConnParams(connParams *cli.ConnectionConfig) *connections.InfluxConnectionParams {
 	return &connections.InfluxConnectionParams{
-		Server:   connParams.InputHost,
-		Database: connParams.InputDb,
-		Username: connParams.InputUser,
-		Password: connParams.InputPass,
+		Server:      connParams.InputHost,
+		Database:    connParams.InputDb,
+		Username:    connParams.InputUser,
+		Password:    connParams.InputPass,
+		UnsafeHTTPS: connParams.InputUnsafeHTTPS,
 	}
 }

--- a/cmd/outflux/schema_transfer.go
+++ b/cmd/outflux/schema_transfer.go
@@ -75,10 +75,11 @@ func transferSchema(app *appContext, connArgs *cli.ConnectionConfig, args *cli.M
 
 func discoverMeasures(app *appContext, connArgs *cli.ConnectionConfig) ([]string, error) {
 	client, err := app.ics.NewConnection(&connections.InfluxConnectionParams{
-		Server:   connArgs.InputHost,
-		Username: connArgs.InputUser,
-		Password: connArgs.InputPass,
-		Database: connArgs.InputDb,
+		Server:      connArgs.InputHost,
+		Username:    connArgs.InputUser,
+		Password:    connArgs.InputPass,
+		Database:    connArgs.InputDb,
+		UnsafeHTTPS: connArgs.InputUnsafeHTTPS,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/cli/connection_config.go
+++ b/internal/cli/connection_config.go
@@ -7,6 +7,7 @@ type ConnectionConfig struct {
 	InputMeasures      []string
 	InputUser          string
 	InputPass          string
+	InputUnsafeHTTPS   bool
 	OutputDbConnString string
 	OutputSchema       string
 }

--- a/internal/cli/flagparsers/connection_args_parser.go
+++ b/internal/cli/flagparsers/connection_args_parser.go
@@ -16,15 +16,16 @@ func FlagsToConnectionConfig(flags *pflag.FlagSet, args []string) (*cli.Connecti
 	inputUser, _ := flags.GetString(InputUserFlag)
 	inputPass, _ := flags.GetString(InputPassFlag)
 	inputHost, _ := flags.GetString(InputServerFlag)
+	inputUnsafe, _ := flags.GetBool(InputUnsafeHTTPSFlag)
 	outputConnString, _ := flags.GetString(OutputConnFlag)
 	schema, _ := flags.GetString(OutputSchemaFlag)
-
 	return &cli.ConnectionConfig{
 		InputDb:            args[0],
 		InputMeasures:      args[1:],
 		InputHost:          inputHost,
 		InputUser:          inputUser,
 		InputPass:          inputPass,
+		InputUnsafeHTTPS:   inputUnsafe,
 		OutputDbConnString: outputConnString,
 		OutputSchema:       schema,
 	}, nil

--- a/internal/cli/flagparsers/connection_flags.go
+++ b/internal/cli/flagparsers/connection_flags.go
@@ -18,6 +18,10 @@ func AddConnectionFlagsToCmd(cmd *cobra.Command) {
 		InputPassFlag,
 		DefaultInputPass,
 		"Password to use when connecting to the input database. If set overrides $INFLUX_PASSWORD")
+	cmd.PersistentFlags().Bool(
+		InputUnsafeHTTPSFlag,
+		DefaultInputUnsafeHTTPS,
+		"Should 'InsecureSkipVerify' be passed to the input connection")
 	cmd.PersistentFlags().String(
 		OutputConnFlag,
 		DefaultOutputConn,

--- a/internal/cli/flagparsers/flags.go
+++ b/internal/cli/flagparsers/flags.go
@@ -10,6 +10,7 @@ const (
 	InputServerFlag             = "input-server"
 	InputUserFlag               = "input-user"
 	InputPassFlag               = "input-pass"
+	InputUnsafeHTTPSFlag        = "input-unsafe-https"
 	OutputConnFlag              = "output-conn"
 	SchemaStrategyFlag          = "schema-strategy"
 	CommitStrategyFlag          = "commit-strategy"
@@ -31,6 +32,7 @@ const (
 	DefaultInputServer             = "http://localhost:8086"
 	DefaultInputUser               = ""
 	DefaultInputPass               = ""
+	DefaultInputUnsafeHTTPS        = false
 	DefaultOutputConn              = "sslmode=disable"
 	DefaultOutputSchema            = ""
 	DefaultSchemaStrategy          = schemaconfig.CreateIfMissing

--- a/internal/connections/influx_connection.go
+++ b/internal/connections/influx_connection.go
@@ -15,10 +15,11 @@ const (
 
 // InfluxConnectionParams represents the parameters required to open a InfluxDB connection
 type InfluxConnectionParams struct {
-	Server   string
-	Username string
-	Password string
-	Database string
+	Server      string
+	Username    string
+	Password    string
+	Database    string
+	UnsafeHTTPS bool
 }
 
 // InfluxConnectionService creates new clients connected to some Influx server
@@ -51,7 +52,12 @@ func (s *defaultInfluxConnectionService) NewConnection(params *InfluxConnectionP
 	} else {
 		pass = os.Getenv(PassEnvVar)
 	}
-	clientConfig := influx.HTTPConfig{Addr: params.Server, Username: user, Password: pass}
+	clientConfig := influx.HTTPConfig{
+		Addr:               params.Server,
+		Username:           user,
+		Password:           pass,
+		InsecureSkipVerify: params.UnsafeHTTPS,
+	}
 
 	newClient, err := influx.NewHTTPClient(clientConfig)
 	return newClient, err


### PR DESCRIPTION
Influx HTTP client has an option to skip HTTPs verification.
A flag is added that allows the user to disable the verification
explicitly.

As requested in #53