### PR TITLE
Handle fields with different types accross shards

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,21 @@
 
 This repo contains code for exporting complete InfluxDB databases or selected measurements to TimescaleDB.
 
+## Table of Contents
+
+1. [Installation](#Installation)
+  - [Installing from source](#Installing\ from\ Source)
+  - [Binary releases](#Binary\ releases)
+2. [How to use](#How\ to\ use)
+  - [Before using it](#Before\ using\ it)
+  - [⚠️Connection params ⚠️](#⚠️\ Connection\ params\ ⚠️)
+  - [Schema Transfer](#Schema\ Transfer)
+  - [Migrate](#Migrate)
+  - [Examples](#Examples)
+3. [Connection](#Connection)
+  - [TimescaleDB connection params](#TimescaleDB\ connection\ params)
+  - [InfluxDB connection params](#InfluxDB\ connection\ params)
+4. [Known limitations](#Known\ limitations)
 ## Installation
 
 ### Installing from source
@@ -60,21 +75,22 @@ For example `outflux schema-transfer benchmark cpu mem` will discover the schema
 
 Available flags for schema-transfer are:
 
-| flag               | type    | default               | description |
-|--------------------|---------|-----------------------|-------------|
-| input-server       | string  | http://localhost:8086 | Location of the input database, http(s)://location:port. |
-| input-pass         | string  |                       | Password to use when connecting to the input database |
-| input-user         | string  |                       | Username to use when connecting to the input database |
-| input-unsafe-https | bool    | false                 | Should 'InsecureSkipVerify' be passed to the input connection |
-| retention-policy   | string  | autogen               | The retention policy to select the tags and fields from |
-| output-conn        | string  | sslmode=disable       | Connection string to use to connect to the output database|
-| output-schema      | string  |                       | The schema of the output database that the data will be inserted into |
-| schema-strategy    | string  | CreateIfMissing       | Strategy to use for preparing the schema of the output database. Valid options: ValidateOnly, CreateIfMissing, DropAndCreate, DropCascadeAndCreate |
-| tags-as-json       | bool    | false                 | If this flag is set to true, then the Tags of the influx measures being exported will be combined into a single JSONb column in Timescale |
-| tags-column        | string  | tags                  | When `tags-as-json` is set, this column specifies the name of the JSON column for the tags |
-| fields-as-json     | bool    | false                 | If this flag is set to true, then the Fields of the influx measures being exported will be combined into a single JSONb column in Timescale |
-| fields-column      | string  | fields                | When `fields-as-json` is set, this column specifies the name of the JSON column for the fields |
-| quiet              | bool    | false                 | If specified will suppress any log to STDOUT |
+| flag                      | type    | default               | description |
+|---------------------------|---------|-----------------------|-------------|
+| input-server              | string  | http://localhost:8086 | Location of the input database, http(s)://location:port. |
+| input-pass                | string  |                       | Password to use when connecting to the input database |
+| input-user                | string  |                       | Username to use when connecting to the input database |
+| input-unsafe-https        | bool    | false                 | Should 'InsecureSkipVerify' be passed to the input connection |
+| retention-policy          | string  | autogen               | The retention policy to select the tags and fields from |
+| output-conn               | string  | sslmode=disable       | Connection string to use to connect to the output database|
+| output-schema             | string  |                       | The schema of the output database that the data will be inserted into |
+| schema-strategy           | string  | CreateIfMissing       | Strategy to use for preparing the schema of the output database. Valid options: ValidateOnly, CreateIfMissing, DropAndCreate, DropCascadeAndCreate |
+| tags-as-json              | bool    | false                 | If this flag is set to true, then the Tags of the influx measures being exported will be combined into a single JSONb column in Timescale |
+| tags-column               | string  | tags                  | When `tags-as-json` is set, this column specifies the name of the JSON column for the tags |
+| fields-as-json            | bool    | false                 | If this flag is set to true, then the Fields of the influx measures being exported will be combined into a single JSONb column in Timescale |
+| fields-column             | string  | fields                | When `fields-as-json` is set, this column specifies the name of the JSON column for the fields |
+| multishard-int-float-cast | bool    | false                 | If a field is Int64 in one shard, and Float64 in another, with this flag it will be cast to Float64 despite possible data loss |
+| quiet                     | bool    | false                 | If specified will suppress any log to STDOUT |
 
 ### Migrate
 
@@ -115,6 +131,7 @@ Available flags are:
 | tags-column      | string  | tags                  | When `tags-as-json` is set, this column specifies the name of the JSON column for the tags |
 | fields-as-json   | bool    | false                 | If this flag is set to true, then the Fields of the influx measures being exported will be combined into a single JSONb column in Timescale |
 | fields-column    | string  | fields                | When `fields-as-json` is set, this column specifies the name of the JSON column for the fields |
+| multishard-int-float-cast | bool    | false                 | If a field is Int64 in one shard, and Float64 in another, with this flag it will be cast to Float64 despite possible data loss |
 | quiet                      | bool    | false                 | If specified will suppress any log to STDOUT |
 
 ### Examples
@@ -183,4 +200,17 @@ Also you can specify to Outflux to skip HTTPS verification when communicating wi
 
 ## Known limitations
 
-Outflux doesn't support fields that have the same name but different data types across shards in InfluxDB (https://github.com/timescale/outflux/issues/59)
+### Fields with different data types across shards
+
+Outflux doesn't support fields that have the same name but different data types across shards in InfluxDB, 
+**UNLESS** the field is an `integer` and `float` in the InfluxDB shards. 
+InfluxDB can store the fields as `integer` (64bit integer), `float` (64bit float), `string`, and `boolean`.
+You can specify the `multishard-int-float-cast` flag. This will tell Outflux to cast the `integer` values to 
+`float` values. A 64bit float can't hold all the int64 values, so this may result in scrambled data (for values > 2^53). 
+
+If the same field is of any of the other possible InfluxDB types, an error will be thrown, since the values can't be 
+converted.
+
+This is also an issue even if you select a time interval in which a field has a consistent type, but exists as a different type
+in a shard outside of that interval. This is because the `SHOW FIELD KEYS FROM measurement_name` doesn't accept a time interval
+for which you would be asking

--- a/cmd/outflux/migrate.go
+++ b/cmd/outflux/migrate.go
@@ -55,7 +55,7 @@ func initMigrateCmd() *cobra.Command {
 	migrateCmd.PersistentFlags().Bool(flagparsers.FieldsAsJSONFlag, flagparsers.DefaultFieldsAsJSON, "If this flag is set to true, then the Fields of the influx measures being exported will be combined into a single JSONb column in Timescale")
 	migrateCmd.PersistentFlags().String(flagparsers.FieldsColumnFlag, flagparsers.DefaultFieldsColumn, "When "+flagparsers.FieldsAsJSONFlag+" is set, this column specifies the name of the JSON column for the fields")
 	migrateCmd.PersistentFlags().String(flagparsers.OutputSchemaFlag, flagparsers.DefaultOutputSchema, "The schema of the output database that the data will be inserted into")
-
+	migrateCmd.PersistentFlags().Bool(flagparsers.MultishardIntFloatCast, flagparsers.DefaultMultishardIntFloatCast, "If a field is Int64 in one shard, and Float64 in another, with this flag it will be cast to Float64 despite possible data loss")
 	return migrateCmd
 }
 
@@ -70,7 +70,7 @@ func migrate(app *appContext, connArgs *cli.ConnectionConfig, args *cli.Migratio
 		if err != nil {
 			return fmt.Errorf("could not open connection to Influx Server\n%v", err)
 		}
-		connArgs.InputMeasures, err = discoverMeasures(app, influxConn, connArgs.InputDb, args.RetentionPolicy)
+		connArgs.InputMeasures, err = discoverMeasures(app, influxConn, connArgs.InputDb, args.RetentionPolicy, args.OnConflictConvertIntToFloat)
 		influxConn.Close()
 		if err != nil {
 			return fmt.Errorf("could not discover the available measures for the input db '%s'", connArgs.InputDb)

--- a/cmd/outflux/mocks_for_test.go
+++ b/cmd/outflux/mocks_for_test.go
@@ -28,7 +28,7 @@ func (m *mockService) NewConnection(arg *connections.InfluxConnectionParams) (in
 	return m.inflConn, m.inflConnErr
 }
 
-func (m *mockService) Influx(c influx.Client, db, rp string) schemamanagement.SchemaManager {
+func (m *mockService) Influx(c influx.Client, db, rp string, convertIntToFloat bool) schemamanagement.SchemaManager {
 	return m.inflSchemMngr
 }
 

--- a/cmd/outflux/schema_transfer_test.go
+++ b/cmd/outflux/schema_transfer_test.go
@@ -21,7 +21,7 @@ func TestDiscoverMeasures(t *testing.T) {
 		ics:                  mockAll,
 		schemaManagerService: mockAll,
 	}
-	_, err := discoverMeasures(app, mockClient, "db", "autogen")
+	_, err := discoverMeasures(app, mockClient, "db", "autogen", true)
 	if err != nil {
 		t.Errorf("unexpected error:%v", err)
 	}

--- a/internal/cli/extraction_conf_creator.go
+++ b/internal/cli/extraction_conf_creator.go
@@ -18,14 +18,15 @@ type defaultExtractionConfCreator struct{}
 
 func (d *defaultExtractionConfCreator) create(pipeID, db, measure string, conf *MigrationConfig) *config.ExtractionConfig {
 	measureExtractionConf := &config.MeasureExtraction{
-		Database:        db,
-		Measure:         measure,
-		From:            conf.From,
-		To:              conf.To,
-		ChunkSize:       conf.ChunkSize,
-		Limit:           conf.Limit,
-		SchemaOnly:      conf.SchemaOnly,
-		RetentionPolicy: conf.RetentionPolicy,
+		Database:                    db,
+		Measure:                     measure,
+		From:                        conf.From,
+		To:                          conf.To,
+		ChunkSize:                   conf.ChunkSize,
+		Limit:                       conf.Limit,
+		SchemaOnly:                  conf.SchemaOnly,
+		RetentionPolicy:             conf.RetentionPolicy,
+		OnConflictConvertIntToFloat: conf.OnConflictConvertIntToFloat,
 	}
 
 	ex := &config.ExtractionConfig{

--- a/internal/cli/flagparsers/flags.go
+++ b/internal/cli/flagparsers/flags.go
@@ -29,6 +29,11 @@ const (
 	TagsColumnFlag              = "tags-column"
 	FieldsAsJSONFlag            = "fields-as-json"
 	FieldsColumnFlag            = "fields-column"
+	// InfluxDB can have different data types for the same field accross
+	// different shards. If a field is discovered with an Int64 and a Float64 type
+	// and this flag is TRUE it will allow the field to be converted to float,
+	// otherwise it will return an error.
+	MultishardIntFloatCast = "multishard-int-float-cast"
 
 	DefaultInputServer             = "http://localhost:8086"
 	DefaultInputUser               = ""
@@ -49,4 +54,5 @@ const (
 	DefaultTagsColumn              = "tags"
 	DefaultFieldsAsJSON            = false
 	DefaultFieldsColumn            = "fields"
+	DefaultMultishardIntFloatCast  = false
 )

--- a/internal/cli/flagparsers/migrate_args_parser.go
+++ b/internal/cli/flagparsers/migrate_args_parser.go
@@ -68,7 +68,6 @@ func FlagsToMigrateConfig(flags *pflag.FlagSet, args []string) (*cli.ConnectionC
 	to, _ := flags.GetString(ToFlag)
 	tagsAsJSON, _ := flags.GetBool(TagsAsJSONFlag)
 	tagsColumn, _ := flags.GetString(TagsColumnFlag)
-
 	if tagsAsJSON && tagsColumn == "" {
 		return nil, nil, fmt.Errorf("When the '%s' flag is set, the '%s' must also have a value", TagsAsJSONFlag, TagsColumnFlag)
 	}
@@ -80,6 +79,8 @@ func FlagsToMigrateConfig(flags *pflag.FlagSet, args []string) (*cli.ConnectionC
 	}
 	outputSchema, _ := flags.GetString(OutputSchemaFlag)
 	rp, _ := flags.GetString(RetentionPolicyFlag)
+	intToFloat, _ := flags.GetBool(MultishardIntFloatCast)
+
 	migrateArgs := &cli.MigrationConfig{
 		RetentionPolicy:                      rp,
 		OutputSchemaStrategy:                 strategy,
@@ -98,6 +99,7 @@ func FlagsToMigrateConfig(flags *pflag.FlagSet, args []string) (*cli.ConnectionC
 		TagsCol:                              tagsColumn,
 		FieldsAsJSON:                         fieldsAsJSON,
 		FieldsCol:                            fieldsColumn,
+		OnConflictConvertIntToFloat:          intToFloat,
 	}
 
 	return connectionArgs, migrateArgs, nil

--- a/internal/cli/flagparsers/schema_transfer_args_parser.go
+++ b/internal/cli/flagparsers/schema_transfer_args_parser.go
@@ -39,17 +39,18 @@ func FlagsToSchemaTransferConfig(flags *pflag.FlagSet, args []string) (*cli.Conn
 		return nil, nil, fmt.Errorf("value for the '%s' flag must be a true or false", QuietFlag)
 	}
 	outputSchema, _ := flags.GetString(OutputSchemaFlag)
-
+	intToFloat, _ := flags.GetBool(MultishardIntFloatCast)
 	return connectionArgs, &cli.MigrationConfig{
-		RetentionPolicy:      retentionPolicy,
-		OutputSchema:         outputSchema,
-		OutputSchemaStrategy: strategy,
-		Quiet:                quiet,
-		SchemaOnly:           true,
-		ChunkSize:            1,
-		TagsAsJSON:           tagsAsJSON,
-		TagsCol:              tagsColumn,
-		FieldsAsJSON:         fieldsAsJSON,
-		FieldsCol:            fieldsColumn,
+		RetentionPolicy:             retentionPolicy,
+		OutputSchema:                outputSchema,
+		OutputSchemaStrategy:        strategy,
+		Quiet:                       quiet,
+		SchemaOnly:                  true,
+		ChunkSize:                   1,
+		TagsAsJSON:                  tagsAsJSON,
+		TagsCol:                     tagsColumn,
+		FieldsAsJSON:                fieldsAsJSON,
+		FieldsCol:                   fieldsColumn,
+		OnConflictConvertIntToFloat: intToFloat,
 	}, nil
 }

--- a/internal/cli/migration_config.go
+++ b/internal/cli/migration_config.go
@@ -25,4 +25,5 @@ type MigrationConfig struct {
 	TagsCol                              string
 	FieldsAsJSON                         bool
 	FieldsCol                            string
+	OnConflictConvertIntToFloat          bool
 }

--- a/internal/cli/transformer_service.go
+++ b/internal/cli/transformer_service.go
@@ -70,8 +70,11 @@ func (t *transformerService) fetchTags(infConn influx.Client, db, rp, measure st
 }
 
 func (t *transformerService) fetchFields(infConn influx.Client, db, rp, measure string) ([]string, error) {
+	// Because the columns are combined in a JSON it doesn't matter if they are
+	// int or float in different shards
+	onConflictConvertIntToFloat := true
 	fetchFn := func() ([]*idrf.Column, error) {
-		return t.influxFieldExplorer.DiscoverMeasurementFields(infConn, db, rp, measure)
+		return t.influxFieldExplorer.DiscoverMeasurementFields(infConn, db, rp, measure, onConflictConvertIntToFloat)
 	}
 
 	return fetch(fetchFn)

--- a/internal/extraction/config/extraction_config.go
+++ b/internal/extraction/config/extraction_config.go
@@ -11,14 +11,15 @@ const (
 
 // MeasureExtraction holds config properties for a single measure
 type MeasureExtraction struct {
-	Database        string
-	Measure         string
-	From            string
-	To              string
-	ChunkSize       uint16
-	Limit           uint64
-	SchemaOnly      bool
-	RetentionPolicy string
+	Database                    string
+	Measure                     string
+	From                        string
+	To                          string
+	ChunkSize                   uint16
+	Limit                       uint64
+	SchemaOnly                  bool
+	RetentionPolicy             string
+	OnConflictConvertIntToFloat bool
 }
 
 // ValidateMeasureExtractionConfig validates the fields

--- a/internal/extraction/extraction_service.go
+++ b/internal/extraction/extraction_service.go
@@ -24,12 +24,13 @@ type extractorService struct {
 }
 
 func (e *extractorService) InfluxExtractor(conn influx.Client, conf *config.ExtractionConfig) (Extractor, error) {
-	err := config.ValidateMeasureExtractionConfig(conf.MeasureExtraction)
+	exConf := conf.MeasureExtraction
+	err := config.ValidateMeasureExtractionConfig(exConf)
 	if err != nil {
 		return nil, fmt.Errorf("measure extraction config is not valid: %s", err.Error())
 	}
 
-	sm := e.schemaManagerService.Influx(conn, conf.MeasureExtraction.Database, conf.MeasureExtraction.RetentionPolicy)
+	sm := e.schemaManagerService.Influx(conn, exConf.Database, exConf.RetentionPolicy, exConf.OnConflictConvertIntToFloat)
 	dataProducer := influxExtraction.NewDataProducer(conf.ExtractorID, conn)
 	return &influxExtraction.Extractor{
 		Config:       conf,

--- a/internal/idrf/data_type.go
+++ b/internal/idrf/data_type.go
@@ -20,25 +20,25 @@ const (
 func (d DataType) String() string {
 	switch d {
 	case IDRFBoolean:
-		return "IDRFBoolean"
+		return "Boolean"
 	case IDRFDouble:
-		return "IDRFDouble"
+		return "Double"
 	case IDRFInteger32:
-		return "IDRFInteger32"
+		return "Integer32"
 	case IDRFString:
-		return "IDRFString"
+		return "String"
 	case IDRFTimestamp:
 		return "IDRFTimestamp"
 	case IDRFTimestamptz:
-		return "IDRFTimestamptz"
+		return "Timestamptz"
 	case IDRFInteger64:
-		return "IDRFInteger64"
+		return "Integer64"
 	case IDRFSingle:
-		return "IDRFSingle"
+		return "Single"
 	case IDRFJson:
-		return "IDRFJson"
+		return "Json"
 	case IDRFUnknown:
-		return "IDRFUnknown"
+		return "Unknown"
 	default:
 		panic("Unexpected value")
 	}
@@ -50,15 +50,12 @@ func (d DataType) CanFitInto(other DataType) bool {
 		return true
 	}
 
-	if d == IDRFInteger32 {
+	switch d {
+	case IDRFInteger32:
 		return other == IDRFSingle || other == IDRFDouble || other == IDRFInteger64
-	}
-
-	if d == IDRFInteger64 || d == IDRFSingle {
+	case IDRFSingle:
 		return other == IDRFDouble
-	}
-
-	if d == IDRFTimestamp {
+	case IDRFTimestamp:
 		return other == IDRFTimestamptz
 	}
 

--- a/internal/idrf/data_type_test.go
+++ b/internal/idrf/data_type_test.go
@@ -25,29 +25,29 @@ func TestCanFitInto(t *testing.T) {
 	for _, dt := range allTypes {
 		if dt == IDRFInteger64 || dt == IDRFSingle || dt == IDRFDouble {
 			if !IDRFInteger32.CanFitInto(dt) {
-				t.Errorf("should've fit")
+				t.Errorf("%s should've fit in %s", IDRFInteger32, dt)
 			}
 		} else if dt != IDRFInteger32 && IDRFInteger32.CanFitInto(dt) {
-			t.Error("shouldn't have fit")
+			t.Errorf("%s shouldn't have fit in %s", IDRFInteger32, dt)
 			continue
 		}
 
 		if dt == IDRFDouble {
-			if !IDRFInteger64.CanFitInto(dt) && !IDRFSingle.CanFitInto(dt) {
-				t.Error("should've fit")
+			if !IDRFSingle.CanFitInto(dt) {
+				t.Errorf("%s should've fit in %s", IDRFSingle, dt)
 			}
-		} else if dt != IDRFInteger64 && dt != IDRFSingle && (IDRFInteger64.CanFitInto(dt) || IDRFSingle.CanFitInto(dt)) {
-			t.Error("shouldn't have")
+		} else if dt != IDRFSingle && IDRFSingle.CanFitInto(dt) {
+			t.Errorf("%s shouldn't have fit in %s", IDRFSingle, dt)
 			continue
 		}
 
 		if dt == IDRFTimestamptz && !IDRFTimestamp.CanFitInto(dt) {
-			t.Error("should've fit")
+			t.Errorf("%s should've fit in %s", IDRFTimestamp, dt)
 			continue
 		}
 
 		if dt != IDRFString && dt.CanFitInto(IDRFString) {
-			t.Error("shoulnd't have fit")
+			t.Errorf("%s shouldn't have fit in %s", dt, IDRFString)
 		}
 	}
 }

--- a/internal/schemamanagement/influx/dataset_constructor.go
+++ b/internal/schemamanagement/influx/dataset_constructor.go
@@ -15,25 +15,27 @@ type dataSetConstructor interface {
 
 // NewDataSetConstructor creates a new instance of a DataSetConstructor
 func newDataSetConstructor(
-	db, rp string,
+	db, rp string, onConflictConvertIntToFloat bool,
 	client influx.Client,
 	tagExplorer discovery.TagExplorer,
 	fieldExplorer discovery.FieldExplorer) dataSetConstructor {
 	return &defaultDSConstructor{
-		database:      db,
-		rp:            rp,
-		influxClient:  client,
-		tagExplorer:   tagExplorer,
-		fieldExplorer: fieldExplorer,
+		database:                    db,
+		rp:                          rp,
+		influxClient:                client,
+		tagExplorer:                 tagExplorer,
+		fieldExplorer:               fieldExplorer,
+		onConflictConvertIntToFloat: onConflictConvertIntToFloat,
 	}
 }
 
 type defaultDSConstructor struct {
-	database      string
-	rp            string
-	tagExplorer   discovery.TagExplorer
-	fieldExplorer discovery.FieldExplorer
-	influxClient  influx.Client
+	database                    string
+	rp                          string
+	onConflictConvertIntToFloat bool
+	tagExplorer                 discovery.TagExplorer
+	fieldExplorer               discovery.FieldExplorer
+	influxClient                influx.Client
 }
 
 func (d *defaultDSConstructor) construct(measure string) (*idrf.DataSet, error) {
@@ -42,7 +44,7 @@ func (d *defaultDSConstructor) construct(measure string) (*idrf.DataSet, error) 
 		return nil, fmt.Errorf("could not discover the tags of measurement '%s'\n%v", measure, err)
 	}
 
-	idrfFields, err := d.fieldExplorer.DiscoverMeasurementFields(d.influxClient, d.database, d.rp, measure)
+	idrfFields, err := d.fieldExplorer.DiscoverMeasurementFields(d.influxClient, d.database, d.rp, measure, d.onConflictConvertIntToFloat)
 	if err != nil {
 		return nil, fmt.Errorf("could not discover the fields of measure '%s'\n%v", measure, err)
 	}

--- a/internal/schemamanagement/influx/dataset_constructor_test.go
+++ b/internal/schemamanagement/influx/dataset_constructor_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestNewDataSetConstructor(t *testing.T) {
-	newDataSetConstructor("", "rp", nil, nil, nil)
+	newDataSetConstructor("", "rp", true, nil, nil, nil)
 }
 
 func TestConstruct(t *testing.T) {
@@ -84,6 +84,6 @@ func (m *mocker) DiscoverMeasurementTags(influxClient influx.Client, db, rp, mea
 	return m.tags, m.tagsErr
 }
 
-func (m *mocker) DiscoverMeasurementFields(influxClient influx.Client, db, rp, measurement string) ([]*idrf.Column, error) {
+func (m *mocker) DiscoverMeasurementFields(influxClient influx.Client, db, rp, measurement string, convertIntToFloat bool) ([]*idrf.Column, error) {
 	return m.fields, m.fieldsErr
 }

--- a/internal/schemamanagement/influx/discovery/field_discovery.go
+++ b/internal/schemamanagement/influx/discovery/field_discovery.go
@@ -2,6 +2,8 @@ package discovery
 
 import (
 	"fmt"
+	"log"
+	"sort"
 
 	influx "github.com/influxdata/influxdb/client/v2"
 	"github.com/timescale/outflux/internal/idrf"
@@ -15,7 +17,7 @@ const (
 // FieldExplorer defines an API for discovering InfluxDB fields of a specified measurement
 type FieldExplorer interface {
 	// DiscoverMeasurementFields creates the ColumnInfo for the Fields of a given measurement
-	DiscoverMeasurementFields(influxClient influx.Client, db, rp, measurement string) ([]*idrf.Column, error)
+	DiscoverMeasurementFields(influxClient influx.Client, db, rp, measurement string, onConflictConvertIntToFloat bool) ([]*idrf.Column, error)
 }
 
 type defaultFieldExplorer struct {
@@ -27,13 +29,17 @@ func NewFieldExplorer(queryService influxqueries.InfluxQueryService) FieldExplor
 	return &defaultFieldExplorer{queryService}
 }
 
-func (fe *defaultFieldExplorer) DiscoverMeasurementFields(influxClient influx.Client, db, rp, measurement string) ([]*idrf.Column, error) {
+// InfluxDB can have different data types for the same field accross
+// different shards. If a field is discovered with Int64 and Float64 type
+// and the 'onConflictConvertIntToFloat' flag is TRUE it will allow the field to be converted to float,
+// otherwise it will return an error
+func (fe *defaultFieldExplorer) DiscoverMeasurementFields(influxClient influx.Client, db, rp, measurement string, onConflictConvertIntToFloat bool) ([]*idrf.Column, error) {
 	fields, err := fe.fetchMeasurementFields(influxClient, db, rp, measurement)
 	if err != nil {
 		return nil, fmt.Errorf("error fetching fields for measurement '%s'\n%v", measurement, err)
 	}
 
-	return convertFields(fields)
+	return convertFields(fields, onConflictConvertIntToFloat)
 }
 
 func (fe *defaultFieldExplorer) fetchMeasurementFields(influxClient influx.Client, db, rp, measurement string) ([][2]string, error) {
@@ -66,14 +72,26 @@ func (fe *defaultFieldExplorer) fetchMeasurementFields(influxClient influx.Clien
 	return fieldKeys, nil
 }
 
-func convertFields(fieldsWithType [][2]string) ([]*idrf.Column, error) {
-	columns := make([]*idrf.Column, len(fieldsWithType))
-	for i, field := range fieldsWithType {
-		columnType := convertDataType(field[1])
-		idrfColumn, err := idrf.NewColumn(field[0], columnType)
+func convertFields(fieldsWithType [][2]string, convertInt64ToFloat64 bool) ([]*idrf.Column, error) {
+	columnMap, err := chooseDataTypeForFields(fieldsWithType, convertInt64ToFloat64)
+	if err != nil {
+		return nil, err
+	}
+
+	columns := make([]*idrf.Column, len(columnMap))
+	currentColumn := 0
+	columnNames := make([]string, len(columnMap))
+	for columnName := range columnMap {
+		columnNames[currentColumn] = columnName
+		currentColumn++
+	}
+	sort.Strings(columnNames)
+	for i, columnName := range columnNames {
+		columnType := columnMap[columnName]
+		idrfColumn, err := idrf.NewColumn(columnName, columnType)
 
 		if err != nil {
-			return nil, fmt.Errorf("could not convert fields to IDRF. \n%v", err.Error())
+			return nil, fmt.Errorf("could not convert field to Intermediate Data Representation Format. \n%v", err.Error())
 		}
 
 		columns[i] = idrfColumn
@@ -95,4 +113,42 @@ func convertDataType(influxType string) idrf.DataType {
 	default:
 		panic("Unexpected value")
 	}
+}
+
+func chooseDataTypeForFields(fieldsWithType [][2]string, convertInt64ToFloat64 bool) (map[string]idrf.DataType, error) {
+	columnMap := make(map[string]idrf.DataType)
+	for _, field := range fieldsWithType {
+		fieldName := field[0]
+		fieldType := field[1]
+		columnType := convertDataType(fieldType)
+		existingType, ok := columnMap[fieldName]
+		if !ok {
+			columnMap[fieldName] = columnType
+			continue
+		} else if columnType.CanFitInto(existingType) {
+			log.Printf("Field %s exists as %s and %s in the same measurement.", fieldName, existingType, columnType)
+			log.Printf("Will be cast to %s during migration", existingType)
+			continue
+		} else if existingType.CanFitInto(columnType) {
+			columnMap[fieldName] = columnType
+			log.Printf("Field %s exists as %s and %s in the same measurement.", fieldName, existingType, columnType)
+			log.Printf("Will be cast to %s during migration", columnType)
+			continue
+		} else if convertInt64ToFloat64 && intFloatCombo(existingType, columnType) {
+			log.Printf("Field %s exists as %s and %s in the same measurement.", fieldName, existingType, columnType)
+			log.Printf("Flag set to cast int64 to float64 for this field during migration")
+			columnMap[fieldName] = idrf.IDRFDouble
+			continue
+		}
+
+		return nil, fmt.Errorf("field '%s' has incomparable types accross multiple shards. "+
+			"Exists with type %s and %s", fieldName, existingType, columnType)
+	}
+
+	return columnMap, nil
+}
+
+func intFloatCombo(oneType, secondType idrf.DataType) bool {
+	return (oneType == idrf.IDRFInteger64 && secondType == idrf.IDRFDouble) ||
+		(oneType == idrf.IDRFDouble && secondType == idrf.IDRFInteger64)
 }

--- a/internal/schemamanagement/influx/discovery/field_discovery_test.go
+++ b/internal/schemamanagement/influx/discovery/field_discovery_test.go
@@ -2,6 +2,7 @@ package discovery
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 
 	influx "github.com/influxdata/influxdb/client/v2"
@@ -17,14 +18,17 @@ func TestDiscoverMeasurementFields(t *testing.T) {
 	rp := "autogen"
 	cases := []testCase{
 		{
+			desc:           "not good, error executing query",
 			expectedError:  true,
 			showQueryError: fmt.Errorf("error executing query"),
-		}, { // empty result returned, error should be result, must have fields
+		}, {
+			desc:          "empty result returned, error should be result, must have fields",
 			expectedError: true,
 			showQueryResult: &influxqueries.InfluxShowResult{
 				Values: [][]string{},
 			},
-		}, { // result has more than two columns
+		}, {
+			desc:          "result has more than two columns",
 			expectedError: true,
 			showQueryResult: &influxqueries.InfluxShowResult{
 				Values: [][]string{
@@ -32,8 +36,8 @@ func TestDiscoverMeasurementFields(t *testing.T) {
 				},
 			},
 		}, {
-			expectedError: false,
-			showQueryResult: &influxqueries.InfluxShowResult{ // proper result
+			desc: "proper result",
+			showQueryResult: &influxqueries.InfluxShowResult{
 				Values: [][]string{
 					{"1", "boolean"},
 					{"2", "float"},
@@ -47,33 +51,110 @@ func TestDiscoverMeasurementFields(t *testing.T) {
 				{Name: "3", DataType: idrf.IDRFInteger64},
 				{Name: "4", DataType: idrf.IDRFString},
 			},
+		}, {
+			desc: "same field, diff types, uncastable",
+			showQueryResult: &influxqueries.InfluxShowResult{
+				Values: [][]string{
+					{"1", "boolean"},
+					{"1", "float"},
+				},
+			},
+			expectedError: true,
+		}, {
+			desc:          "same field, diff types, int and float (flag says error)",
+			expectedError: true,
+			showQueryResult: &influxqueries.InfluxShowResult{
+				Values: [][]string{
+					{"1", "integer"},
+					{"1", "float"},
+				},
+			},
+		}, {
+			desc: "same field, diff types, int and float (flag says no error)",
+			showQueryResult: &influxqueries.InfluxShowResult{
+				Values: [][]string{
+					{"1", "integer"},
+					{"1", "float"},
+				},
+			},
+			onConflictConvertIntToFloat: true,
+			expectedTags: []*idrf.Column{
+				{Name: "1", DataType: idrf.IDRFDouble},
+			},
 		},
 	}
 
 	for _, testCase := range cases {
-		fieldExplorer := defaultFieldExplorer{
-			queryService: mock(testCase),
-		}
-		result, err := fieldExplorer.DiscoverMeasurementFields(mockClient, database, rp, measure)
-		if err != nil && !testCase.expectedError {
-			t.Errorf("unexpected error %v", err)
-		} else if err == nil && testCase.expectedError {
-			t.Errorf("expected error, none received")
-		}
-
-		if testCase.expectedError {
-			continue
-		}
-
-		expected := testCase.expectedTags
-		if len(expected) != len(result) {
-			t.Errorf("еxpected result: '%v', got '%v'", expected, result)
-		}
-
-		for index, resColumn := range result {
-			if resColumn.Name != expected[index].Name || resColumn.DataType != expected[index].DataType {
-				t.Errorf("Expected column: %v, got %v", expected[index], resColumn)
+		t.Run(testCase.desc, func(t *testing.T) {
+			fieldExplorer := defaultFieldExplorer{
+				queryService: mock(testCase),
 			}
-		}
+			result, err := fieldExplorer.DiscoverMeasurementFields(mockClient, database, rp, measure, testCase.onConflictConvertIntToFloat)
+			if err != nil && !testCase.expectedError {
+				t.Errorf("unexpected error %v", err)
+			} else if err == nil && testCase.expectedError {
+				t.Errorf("expected error, none received")
+			}
+
+			if testCase.expectedError {
+				return
+			}
+
+			expected := testCase.expectedTags
+			if len(expected) != len(result) {
+				t.Errorf("expected result: '%v', got '%v'", expected, result)
+			}
+
+			for index, resColumn := range result {
+				if resColumn.Name != expected[index].Name || resColumn.DataType != expected[index].DataType {
+					t.Errorf("expected column: %v, got %v", expected[index], resColumn)
+				}
+			}
+		})
+	}
+}
+
+func TestChooseDataTypeForFields(t *testing.T) {
+	testCases := []struct {
+		desc                        string
+		in                          [][2]string
+		out                         map[string]idrf.DataType
+		onConflictConvertIntToFloat bool
+		expectErr                   bool
+	}{
+		{
+			desc: "All good, single string field",
+			in:   [][2]string{{"a", "string"}},
+			out:  map[string]idrf.DataType{"a": idrf.IDRFString},
+		}, {
+			desc: "All good, multiple distinct fields",
+			in:   [][2]string{{"a", "string"}, {"b", "integer"}, {"c", "float"}},
+			out:  map[string]idrf.DataType{"a": idrf.IDRFString, "b": idrf.IDRFInteger64, "c": idrf.IDRFDouble},
+		}, {
+			desc:      "Not good, incomparable fields",
+			in:        [][2]string{{"a", "string"}, {"b", "integer"}, {"b", "float"}},
+			expectErr: true,
+		}, {
+			desc:                        "Good, incomparable fields, but forced int to float conversion",
+			in:                          [][2]string{{"a", "string"}, {"b", "integer"}, {"b", "float"}},
+			onConflictConvertIntToFloat: true,
+			out:                         map[string]idrf.DataType{"a": idrf.IDRFString, "b": idrf.IDRFDouble},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			got, err := chooseDataTypeForFields(tc.in, tc.onConflictConvertIntToFloat)
+			if err != nil && !tc.expectErr {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			if err == nil && tc.expectErr {
+				t.Error("unexpected lack of error")
+				return
+			}
+			if !reflect.DeepEqual(got, tc.out) {
+				t.Errorf("expected: %v\ngot: %v", tc.out, got)
+			}
+		})
 	}
 }

--- a/internal/schemamanagement/influx/discovery/measure_discovery_test.go
+++ b/internal/schemamanagement/influx/discovery/measure_discovery_test.go
@@ -14,12 +14,14 @@ import (
 type executeShowQueryFn = func(influxClient influx.Client, database, query string) (*influxqueries.InfluxShowResult, error)
 
 type testCase struct {
-	expectedError    bool
-	showQueryResult  *influxqueries.InfluxShowResult
-	showQueryError   error
-	expectedMeasures []string
-	expectedTags     []*idrf.Column
-	fieldsErr        error
+	desc                        string
+	expectedError               bool
+	showQueryResult             *influxqueries.InfluxShowResult
+	showQueryError              error
+	expectedMeasures            []string
+	expectedTags                []*idrf.Column
+	fieldsErr                   error
+	onConflictConvertIntToFloat bool
 }
 
 func TestNewMeasureExplorer(t *testing.T) {
@@ -74,7 +76,7 @@ func TestFetchAvailableMeasurements(t *testing.T) {
 			fieldExplorer: mock,
 		}
 
-		result, err := measureExplorer.FetchAvailableMeasurements(mockClient, database, rp)
+		result, err := measureExplorer.FetchAvailableMeasurements(mockClient, database, rp, false)
 		if err != nil && !testC.expectedError {
 			t.Errorf("no error expected, got: %v", err)
 		} else if err == nil && testC.expectedError {
@@ -112,7 +114,7 @@ func (m *mockAll) ExecuteShowQuery(influxClient influx.Client, database, query s
 	return m.sqRes, m.sqErr
 }
 
-func (m *mockAll) DiscoverMeasurementFields(c influx.Client, db, rp, ms string) ([]*idrf.Column, error) {
+func (m *mockAll) DiscoverMeasurementFields(c influx.Client, db, rp, ms string, onConflictConvertIntToFloat bool) ([]*idrf.Column, error) {
 	return nil, m.fieldsErr
 }
 

--- a/internal/schemamanagement/influx/influx_schema_manager.go
+++ b/internal/schemamanagement/influx/influx_schema_manager.go
@@ -9,33 +9,36 @@ import (
 
 // SchemaManager implements the schemamanagement.SchemaManager interface
 type SchemaManager struct {
-	measureExplorer    discovery.MeasureExplorer
-	influxClient       influx.Client
-	dataSetConstructor dataSetConstructor
-	database           string
-	rp                 string
+	measureExplorer             discovery.MeasureExplorer
+	influxClient                influx.Client
+	dataSetConstructor          dataSetConstructor
+	database                    string
+	rp                          string
+	onConflictConvertIntToFloat bool
 }
 
 // NewSchemaManager creates new schema manager that can discover influx data sets
 func NewSchemaManager(
 	client influx.Client,
 	db, rp string,
+	onConflictConvertIntToFloat bool,
 	me discovery.MeasureExplorer,
 	tagExplorer discovery.TagExplorer,
 	fieldExplorer discovery.FieldExplorer) *SchemaManager {
-	dsConstructor := newDataSetConstructor(db, rp, client, tagExplorer, fieldExplorer)
+	dsConstructor := newDataSetConstructor(db, rp, onConflictConvertIntToFloat, client, tagExplorer, fieldExplorer)
 	return &SchemaManager{
-		measureExplorer:    me,
-		influxClient:       client,
-		dataSetConstructor: dsConstructor,
-		database:           db,
-		rp:                 rp,
+		measureExplorer:             me,
+		influxClient:                client,
+		dataSetConstructor:          dsConstructor,
+		database:                    db,
+		rp:                          rp,
+		onConflictConvertIntToFloat: onConflictConvertIntToFloat,
 	}
 }
 
 // DiscoverDataSets returns a list of the available measurements in the connected
 func (sm *SchemaManager) DiscoverDataSets() ([]string, error) {
-	return sm.measureExplorer.FetchAvailableMeasurements(sm.influxClient, sm.database, sm.rp)
+	return sm.measureExplorer.FetchAvailableMeasurements(sm.influxClient, sm.database, sm.rp, sm.onConflictConvertIntToFloat)
 }
 
 // FetchDataSet for a given data set identifier (retention.measureName, or just measureName)

--- a/internal/schemamanagement/influx/influx_schema_manager_test.go
+++ b/internal/schemamanagement/influx/influx_schema_manager_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestNewInfluxSchemaManager(t *testing.T) {
-	NewSchemaManager(nil, "", "", nil, nil, nil)
+	NewSchemaManager(nil, "", "", true, nil, nil, nil)
 }
 
 func TestDiscoverDataSets(t *testing.T) {
@@ -80,7 +80,7 @@ type ismMeasureExp struct {
 	measureErr error
 }
 
-func (i *ismMeasureExp) FetchAvailableMeasurements(influxClient influx.Client, db, rp string) ([]string, error) {
+func (i *ismMeasureExp) FetchAvailableMeasurements(influxClient influx.Client, db, rp string, convertIntToFloat bool) ([]string, error) {
 	return i.measures, i.measureErr
 }
 

--- a/internal/schemamanagement/schema_manager_service.go
+++ b/internal/schemamanagement/schema_manager_service.go
@@ -10,7 +10,7 @@ import (
 
 // SchemaManagerService defines methods for creating SchemaManagers
 type SchemaManagerService interface {
-	Influx(client influx.Client, db, rp string) SchemaManager
+	Influx(client influx.Client, db, rp string, onConflictConvertIntToFloat bool) SchemaManager
 	TimeScale(dbConn *pgx.Conn, schema string) SchemaManager
 }
 
@@ -30,8 +30,8 @@ type schemaManagerService struct {
 }
 
 // Influx creates new schema manager that can discover influx data sets
-func (s *schemaManagerService) Influx(client influx.Client, db string, rp string) SchemaManager {
-	return influxSchema.NewSchemaManager(client, db, rp, s.measureExplorer, s.tagExplorer, s.fieldExplorer)
+func (s *schemaManagerService) Influx(client influx.Client, db, rp string, onConflictConvertIntToFloat bool) SchemaManager {
+	return influxSchema.NewSchemaManager(client, db, rp, onConflictConvertIntToFloat, s.measureExplorer, s.tagExplorer, s.fieldExplorer)
 }
 
 func (s *schemaManagerService) TimeScale(dbConn *pgx.Conn, schema string) SchemaManager {


### PR DESCRIPTION
InfluxDB allows fields to have different types accross shards.
This commit adds a flag that allows in a case like this, int64 fields
to be cast to float64, even if data loss is possible to occur