### PR TITLE
Work around influx request size limits caused by buildProjection function

### DIFF
--- a/internal/extraction/influx/query_building.go
+++ b/internal/extraction/influx/query_building.go
@@ -19,7 +19,8 @@ const (
 )
 
 func buildSelectCommand(config *config.MeasureExtraction, columns []*idrf.Column) string {
-	projection := buildProjection(columns)
+	//projection := buildProjection(columns)
+        projection := "*"
 	measurementName := buildMeasurementName(config.RetentionPolicy, config.Measure)
 	var command string
 	if config.From != "" && config.To != "" {


### PR DESCRIPTION
This PR is a quick hack that fits my use case to work around #74 

I have not tested this to ensure the column order is maintained without being explicit about the column names in the SELECT ...