### PR TITLE
Fix query for validate if table is hypertable or not

### DIFF
--- a/internal/schemamanagement/ts/schema_explorer.go
+++ b/internal/schemamanagement/ts/schema_explorer.go
@@ -14,9 +14,8 @@ const (
 	                             FROM information_schema.columns
 								 WHERE table_schema = $1 AND table_name = $2;`
 	isHypertableQueryTemplate = `SELECT EXISTS (
-		    						SELECT 1
-								 	FROM timescaledb_information.hypertable
-									 WHERE  table_schema = $1 AND table_name=$2)`
+									 SELECT 1 FROM _timescaledb_catalog.hypertable
+									 WHERE schema_name = $1 AND table_name=$2)`
 	hypertableDimensionsQueryTemplate = `SELECT column_name, column_type
                                          FROM _timescaledb_catalog.dimension d
               							 JOIN _timescaledb_catalog.hypertable h ON d.hypertable_id = h.id


### PR DESCRIPTION
I'm using a timescale at version 13 and I wasn't able to complete the data migration.
The reason was that outflux wasn't able to check if the table is a hyper_table. 

Signed-off-by: Patrik Helia <patashelia@gmail.com>