### PR TITLE
Make the default timestamp datatype as Timestamptz

### DIFF
--- a/internal/schemamanagement/influx/dataset_constructor.go
+++ b/internal/schemamanagement/influx/dataset_constructor.go
@@ -49,7 +49,7 @@ func (d *defaultDSConstructor) construct(measure string) (*idrf.DataSet, error) 
 		return nil, fmt.Errorf("could not discover the fields of measure '%s'\n%v", measure, err)
 	}
 
-	idrfTimeColumn, _ := idrf.NewColumn("time", idrf.IDRFTimestamp)
+	idrfTimeColumn, _ := idrf.NewColumn("time", idrf.IDRFTimestamptz)
 	allColumns := []*idrf.Column{idrfTimeColumn}
 	allColumns = append(allColumns, idrfTags...)
 	allColumns = append(allColumns, idrfFields...)


### PR DESCRIPTION
For correct data manipulation and homogeneity with Telegraf's Postgres plugin, the proper default datatype for timestamps is Timestamptz.